### PR TITLE
fix(worker): copy ArrayBuffer before passing it to the worker if multiple configs are attached

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -164,8 +164,7 @@ From CHANGELOG / known limitations:
 - Lazy worker creation (don't spawn `availableParallelism()` threads for small files)
 - Send tracker config once per worker instead of per batch
 - Defer result merging where possible
-- **`WorkerTaskData.maxGames`** is typed but never sent — wire up or remove
-- Custom tracker `path` + dynamic `import()` remains hacky; document or replace with a registration API
+- Custom tracker `workerModule` + dynamic `import()` remains hacky; document or replace with a registration API
 
 ---
 
@@ -207,5 +206,5 @@ If the goal is “PGN library” rather than “batch analyzer only”, a reason
 | `src/types/analysis.ts`                 | `batchSize` deprecated; ignored by worker-chunk path; still used by legacy MT |
 | `src/types/analysis-runtime.ts`         | Processor-only config/state (split from public analysis types)                |
 | `src/replay/replay-policy.ts`           | Internal `SKIP_REPLAY_WITHOUT_MOVE_TRACKERS` defaults false — opt-in skip     |
-| `src/core/chessalyzer.ts`               | Errors attributed to “bug or unknown PGN format” — no structured diagnostics  |
+| `src/core/analyze.ts`                   | Errors attributed to “bug or unknown PGN format” — no structured diagnostics  |
 | `src/pgn/movetext-tokenizer.ts`         | RAVs and comments share the same strip regex                                  |

--- a/src/core/chess-worker.ts
+++ b/src/core/chess-worker.ts
@@ -23,7 +23,6 @@ function processBatch(msg: WorkerTaskData): WorkerMessage {
     const replay = resolveReplayPolicy(cfg.trackers.move.length > 0);
     const games = parseGamesFromLines(decodePgnChunkBytes(msg.pgnChunkBytes).split('\n'), {
         readInHeader: msg.readInHeader,
-        maxGames: msg.maxGames,
     });
 
     for (const game of games) {

--- a/src/core/game-processor.ts
+++ b/src/core/game-processor.ts
@@ -81,15 +81,17 @@ class GameProcessor {
             chunkLoop: for await (const chunk of readPgnChunks(path, chunkConfig)) {
                 if (fatalError) break;
 
-                for (const [idxCfg, cfg] of this.configs.entries()) {
+                for (const [idxConfig, cfg] of this.configs.entries()) {
                     if (cfg.isDone) continue;
 
+                    // Only one config: transfer original (zero-copy)
+                    // Multiple configs: slice() so each gets its own buffer;
+                    // avoids detaching the underlying buffer
+                    const pgnChunkBytes =
+                        this.configs.length > 1 ? chunk.bytes.slice() : chunk.bytes;
+
                     workerPool.runTask(
-                        {
-                            pgnChunkBytes: chunk.bytes.slice(),
-                            idxConfig: idxCfg,
-                            readInHeader: this.readInHeader,
-                        },
+                        { pgnChunkBytes, idxConfig, readInHeader: this.readInHeader },
                         handleWorkerResult,
                     );
                 }

--- a/src/core/game-processor.ts
+++ b/src/core/game-processor.ts
@@ -86,7 +86,7 @@ class GameProcessor {
 
                     workerPool.runTask(
                         {
-                            pgnChunkBytes: chunk.bytes,
+                            pgnChunkBytes: chunk.bytes.slice(),
                             idxConfig: idxCfg,
                             readInHeader: this.readInHeader,
                         },

--- a/src/replay/game-replayer.ts
+++ b/src/replay/game-replayer.ts
@@ -86,8 +86,10 @@ class GameReplayer {
                 }
             }
         } catch (err) {
-            console.log(game);
-            board.printPosition();
+            if (process.env.CHESSALYZER_DEBUG_REPLAY) {
+                console.log(game);
+                board.printPosition();
+            }
             throw err;
         }
     }

--- a/src/types/worker.ts
+++ b/src/types/worker.ts
@@ -13,7 +13,6 @@ export interface WorkerTaskData {
     pgnChunkBytes: Uint8Array;
     idxConfig: number;
     readInHeader: boolean;
-    maxGames?: number;
 }
 
 /** Worker → main result: counts and optional tracker state to merge. */

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ Module-specific tests live next to the code they exercise (e.g. `src/pgn/__tests
 
 ### Integration tests
 
-Tests that run the full `Chessalyzer` pipeline stay in `test/integration/` because they span parsing, workers, and trackers — not a single module.
+Tests that run the full `analyzePGN` pipeline stay in `test/integration/` because they span parsing, workers, and trackers — not a single module.
 
 ### Fixtures vs corpus
 

--- a/test/integration/fixtures.test.ts
+++ b/test/integration/fixtures.test.ts
@@ -85,6 +85,23 @@ describe('Fixtures', () => {
         });
     });
 
+    describe('worker-parse multi-run', () => {
+        it('processes all runs without sharing detached chunk buffers', async () => {
+            const trackerA = new GameTracker();
+            const trackerB = new GameTracker();
+            const expected = fixtureExpected('results-mix');
+
+            const data = await analyzePGN(fixturePath('results-mix'), {
+                runs: [{ trackers: [trackerA] }, { trackers: [trackerB] }],
+            });
+
+            expect(data.runs[0]?.games).toBe(expected.cntGames);
+            expect(data.runs[1]?.games).toBe(expected.cntGames);
+            expect(trackerA.cntGames).toBe(expected.cntGames);
+            expect(trackerB.cntGames).toBe(expected.cntGames);
+        });
+    });
+
     describe('trackers on fixtures', () => {
         it('runs GameTracker on lichess-headers', async () => {
             const gameTracker = new GameTracker();


### PR DESCRIPTION
- Running a worker analysis with multiple configs caused `TypeError: Underlying ArrayBuffer has been detached from the view or out-of-bounds` due to sharing the same buffer
- Creates a copy of the buffer in the n_config > 1 case
- Remove msg.maxGames from worker message, was unused
- Hide error logging behind debug flag