### PR TITLE
feat(errors): better error handling; add continue-on-error strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A JavaScript library for batch analyzing chess games.
     - [Filtering](#filtering)
     - [Compare Analyses](#compare-analyses)
     - [Multithreading](#multithreaded-analysis)
+    - [Error handling](#error-handling)
 - [Heatmap analysis functions](#heatmap-analysis-functions)
 - [Tracked statistics](#tracked-statistics)
     - [Built-in](#built-in)
@@ -142,6 +143,35 @@ By default, `analyzePGN` uses Node.js [Worker Threads](https://nodejs.org/api/wo
 ```javascript
 await analyzePGN('<pathToPgnFile>', { workers: false });
 ```
+
+## Error handling
+
+By default, `analyzePGN` **aborts on the first replay failure** (illegal or unparseable SAN). The library does not log to the console — callers decide how to handle errors:
+
+```javascript
+import { analyzePGN, getAnalyzeError, isReplayError } from 'chessalyzer.js';
+
+try {
+    await analyzePGN('<pathToPgnFile>');
+} catch (err) {
+    const analyzeError = getAnalyzeError(err);
+    if (isReplayError(analyzeError)) {
+        console.error(
+            `Game ${analyzeError.gameIndex}, move ${analyzeError.moveIndex}: ${analyzeError.san}`,
+        );
+    }
+    throw err;
+}
+```
+
+For large batch runs over mostly trusted exports (e.g. Lichess database dumps), use `onError: 'skip-game'` to continue past bad games and collect a summary:
+
+```javascript
+const result = await analyzePGN('<pathToPgnFile>', { onError: 'skip-game' });
+console.log(result.games, result.skippedGames, result.errors);
+```
+
+`result.errors` contains up to 100 typed replay errors (`gameIndex`, `moveIndex`, `san`, `reason`). Use default `abort` for untrusted or small inputs where a failure should stop the run immediately.
 
 ##### Important
 

--- a/src/core/analysis-config.ts
+++ b/src/core/analysis-config.ts
@@ -53,15 +53,19 @@ function toAnalysisConfig(
 export function normalizeAnalyzeOptions(options?: AnalyzeOptions): {
     configs: AnalysisConfig[];
     multithreadCfg: MultithreadConfig | null;
+    onError: 'abort' | 'skip-game';
 } {
     const opts = options ?? {};
 
     const multithreadCfg: MultithreadConfig | null =
         opts.workers === false ? null : (opts.workers ?? {});
 
+    const onError = opts.onError ?? 'abort';
+
     if (opts.runs && opts.runs.length > 0) {
         return {
             multithreadCfg,
+            onError,
             configs: opts.runs.map((run) =>
                 toAnalysisConfig(run.trackers, run.filter, run.maxGames),
             ),
@@ -70,6 +74,7 @@ export function normalizeAnalyzeOptions(options?: AnalyzeOptions): {
 
     return {
         multithreadCfg,
+        onError,
         configs: [toAnalysisConfig(opts.trackers, opts.filter, opts.maxGames)],
     };
 }
@@ -99,6 +104,8 @@ export function normalizeAnalysisConfigs(
             config,
             processedMoves: 0,
             processedGames: 0,
+            skippedGames: 0,
+            errors: [],
             cntReadGames: 0,
             isDone: false,
         };

--- a/src/core/analyze-errors.ts
+++ b/src/core/analyze-errors.ts
@@ -35,7 +35,7 @@ export function isReplayError(err: unknown): err is ReplayError {
 }
 
 /** Thrown in abort mode; carries the typed replay error for callers. */
-export class AnalyzeAbortError extends Error {
+class AnalyzeAbortError extends Error {
     readonly analyzeError: ReplayError;
 
     constructor(replayError: ReplayError) {

--- a/src/core/analyze-errors.ts
+++ b/src/core/analyze-errors.ts
@@ -1,0 +1,62 @@
+import type {
+    AnalyzeError,
+    ReplayError,
+    ReplayErrorContext,
+    ReplayErrorReason,
+} from '#types/errors';
+
+/** Maximum errors collected per analysis run (across all runs). */
+export const MAX_COLLECTED_ERRORS = 100;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+export function createReplayError(
+    ctx: ReplayErrorContext,
+    reason: ReplayErrorReason,
+    message: string,
+    cause?: unknown,
+): ReplayError {
+    return {
+        code: 'replay',
+        gameIndex: ctx.gameIndex,
+        moveIndex: ctx.moveIndex,
+        san: ctx.san,
+        reason,
+        message,
+        cause,
+    };
+}
+
+export function isReplayError(err: unknown): err is ReplayError {
+    if (!isRecord(err)) return false;
+    return err.code === 'replay' && typeof err.gameIndex === 'number';
+}
+
+/** Thrown in abort mode; carries the typed replay error for callers. */
+export class AnalyzeAbortError extends Error {
+    readonly analyzeError: ReplayError;
+
+    constructor(replayError: ReplayError) {
+        super(replayError.message);
+        this.name = 'AnalyzeAbortError';
+        this.analyzeError = replayError;
+    }
+}
+
+export function toAbortError(replayError: ReplayError): Error {
+    return new AnalyzeAbortError(replayError);
+}
+
+export function getAnalyzeError(err: unknown): AnalyzeError | undefined {
+    if (isReplayError(err)) return err;
+    if (err instanceof AnalyzeAbortError) return err.analyzeError;
+    return undefined;
+}
+
+export function collectError(errors: AnalyzeError[], err: AnalyzeError): void {
+    if (errors.length < MAX_COLLECTED_ERRORS) {
+        errors.push(err);
+    }
+}

--- a/src/core/analyze.ts
+++ b/src/core/analyze.ts
@@ -3,12 +3,19 @@ import { performance } from 'node:perf_hooks';
 import chalk from 'chalk';
 
 import { normalizeAnalyzeOptions } from '#core/analysis-config';
+import { collectError, MAX_COLLECTED_ERRORS } from '#core/analyze-errors';
 import GameProcessor from '#core/game-processor';
 import type { AnalyzeOptions, AnalyzeResult, AnalyzeRunResult } from '#types/analysis';
+import type { AnalyzeError } from '#types/errors';
 import type { HeatmapData } from '#types/tracker';
 
 function buildAnalyzeResult(
-    counts: { cntGames: number; cntMoves: number }[],
+    counts: {
+        cntGames: number;
+        cntMoves: number;
+        skippedGames?: number;
+        errors?: AnalyzeError[];
+    }[],
     durationMs: number,
 ): AnalyzeResult {
     const runs: AnalyzeRunResult[] = counts.map(({ cntGames, cntMoves }) => ({
@@ -19,14 +26,33 @@ function buildAnalyzeResult(
 
     const games = runs.reduce((sum, run) => sum + run.games, 0);
     const moves = runs.reduce((sum, run) => sum + run.moves, 0);
+    const skippedGames = counts.reduce((sum, c) => sum + (c.skippedGames ?? 0), 0);
 
-    return {
+    const errors: AnalyzeError[] = [];
+    for (const c of counts) {
+        if (c.errors) {
+            for (const err of c.errors) {
+                collectError(errors, err);
+            }
+        }
+    }
+
+    const result: AnalyzeResult = {
         durationMs,
         games,
         moves,
         movesPerSecond: durationMs > 0 ? Math.round(moves / (durationMs / 1000)) : 0,
         runs,
     };
+
+    if (skippedGames > 0) {
+        result.skippedGames = skippedGames;
+    }
+    if (errors.length > 0) {
+        result.errors = errors.slice(0, MAX_COLLECTED_ERRORS);
+    }
+
+    return result;
 }
 
 /**
@@ -36,22 +62,13 @@ export async function analyzePGN(
     pathToPgn: string,
     options?: AnalyzeOptions,
 ): Promise<AnalyzeResult> {
-    const { configs, multithreadCfg } = normalizeAnalyzeOptions(options);
-    const gameProcessor = new GameProcessor(configs, multithreadCfg);
+    const { configs, multithreadCfg, onError } = normalizeAnalyzeOptions(options);
+    const gameProcessor = new GameProcessor(configs, multithreadCfg, onError);
 
     const t0 = performance.now();
-
-    try {
-        const counts = await gameProcessor.processPGN(pathToPgn);
-        const durationMs = performance.now() - t0;
-        return buildAnalyzeResult(counts, durationMs);
-    } catch (err) {
-        console.error(
-            'Error occurred during processing. This is probably a bug in the library or you are using an unkown PGN format. Aborting...',
-        );
-        console.error(err);
-        throw err;
-    }
+    const counts = await gameProcessor.processPGN(pathToPgn);
+    const durationMs = performance.now() - t0;
+    return buildAnalyzeResult(counts, durationMs);
 }
 
 /** Print {@link HeatmapData} to the terminal. */

--- a/src/core/chess-worker.ts
+++ b/src/core/chess-worker.ts
@@ -8,6 +8,7 @@ import { resolveReplayPolicy } from '#replay/replay-policy';
 import type { WorkerInitData, WorkerMessage, WorkerTaskData } from '#types/worker';
 
 const initData = workerData as WorkerInitData | undefined;
+const onErrorPolicy: 'abort' | 'skip-game' = initData?.onError ?? 'abort';
 
 /** One GameReplayer per worker thread, reused across batches. */
 const gameReplayer = new GameReplayer();
@@ -26,14 +27,25 @@ function processBatch(msg: WorkerTaskData): WorkerMessage {
     });
 
     for (const game of games) {
-        gameReplayer.processGame(game, cfg, replay);
+        gameReplayer.processGame(
+            game,
+            cfg,
+            replay,
+            cfg.processedGames + cfg.skippedGames,
+            onErrorPolicy,
+        );
     }
 
     const result: WorkerMessage = {
         cntMoves: cfg.processedMoves,
         cntGames: cfg.processedGames,
         idxConfig: msg.idxConfig,
+        skippedGames: cfg.skippedGames,
     };
+
+    if (cfg.errors.length > 0) {
+        result.errors = cfg.errors;
+    }
 
     if (hasTrackers) {
         result.gameTrackers = cfg.trackers.game;

--- a/src/core/game-processor.ts
+++ b/src/core/game-processor.ts
@@ -28,13 +28,19 @@ class GameProcessor {
     readInHeader: boolean;
     multithreadConfig: MultithreadConfig | null;
     useWorkerParse: boolean;
+    readonly onError: 'abort' | 'skip-game';
 
-    constructor(configs: AnalysisConfig[], multithreadCfg: MultithreadConfig | null) {
+    constructor(
+        configs: AnalysisConfig[],
+        multithreadCfg: MultithreadConfig | null,
+        onError: 'abort' | 'skip-game' = 'abort',
+    ) {
         const normalized = normalizeAnalysisConfigs(configs, multithreadCfg);
         this.configs = normalized.configs;
         this.readInHeader = normalized.readInHeader;
         this.useWorkerParse = normalized.useWorkerParse;
         this.multithreadConfig = multithreadCfg;
+        this.onError = onError;
     }
 
     /**
@@ -55,6 +61,7 @@ class GameProcessor {
     private async processPGNWithWorkerParse(path: string): Promise<GameAndMoveCount[]> {
         const workerInitData: WorkerInitData = {
             configs: this.configs.map((cfg) => ({ trackerData: cfg.trackerData })),
+            onError: this.onError,
         };
         const workerPool = new WorkerPool(this.resolveWorkerCount(), WORKER_PATH, workerInitData);
 
@@ -120,6 +127,7 @@ class GameProcessor {
         if (isMultithreaded) {
             const workerInitData: WorkerInitData = {
                 configs: this.configs.map((cfg) => ({ trackerData: cfg.trackerData })),
+                onError: this.onError,
             };
             workerPool = new WorkerPool(this.resolveWorkerCount(), WORKER_PATH, workerInitData);
         }
@@ -175,6 +183,8 @@ class GameProcessor {
                                 game,
                                 cfg,
                                 resolveReplayPolicy(cfg.trackers.move.length > 0),
+                                cfg.processedGames + cfg.skippedGames,
+                                this.onError,
                             );
                         }
                         if (cfg.cntReadGames === cfg.config.cntGames) {

--- a/src/core/tracker-merge.ts
+++ b/src/core/tracker-merge.ts
@@ -1,10 +1,11 @@
+import { collectError } from '#core/analyze-errors';
 import type { GameAndMoveCount } from '#types/analysis';
 import type { GameProcessorAnalysisConfigFull } from '#types/analysis-runtime';
 import type { WorkerMessage } from '#types/worker';
 
 /**
  * Merge one worker batch into the matching main-thread config (trackers + counters).
- * Callers must already have rejected batch-level `result.error` / transport errors.
+ * Callers must already have rejected batch-level `result.error` / transport errors when aborting.
  */
 function mergeWorkerResult(
     configs: GameProcessorAnalysisConfigFull[],
@@ -12,7 +13,8 @@ function mergeWorkerResult(
 ): void {
     if (result.error) throw new Error(result.error);
 
-    const { idxConfig, gameTrackers, moveTrackers, cntMoves, cntGames } = result;
+    const { idxConfig, gameTrackers, moveTrackers, cntMoves, cntGames, skippedGames, errors } =
+        result;
 
     const cfg = configs[idxConfig];
     if (!cfg) return;
@@ -33,6 +35,13 @@ function mergeWorkerResult(
     }
     cfg.processedMoves += cntMoves;
     cfg.processedGames += cntGames;
+    cfg.skippedGames += skippedGames ?? 0;
+
+    if (errors) {
+        for (const err of errors) {
+            collectError(cfg.errors, err);
+        }
+    }
 
     if (cfg.processedGames >= cfg.config.cntGames) {
         cfg.isDone = true;
@@ -79,5 +88,7 @@ export function finishTrackers(configs: GameProcessorAnalysisConfigFull[]): Game
     return configs.map((cfg) => ({
         cntGames: cfg.processedGames,
         cntMoves: cfg.processedMoves,
+        skippedGames: cfg.skippedGames,
+        errors: cfg.errors.length > 0 ? cfg.errors : undefined,
     }));
 }

--- a/src/core/worker-tracker-registry.ts
+++ b/src/core/worker-tracker-registry.ts
@@ -60,6 +60,8 @@ function createAnalysisCfg(
         trackers: { move: [], game: [] },
         processedMoves: 0,
         processedGames: 0,
+        skippedGames: 0,
+        errors: [],
     };
 
     const trackerData = initData?.configs[idxConfig]?.trackerData;
@@ -85,6 +87,8 @@ function createAnalysisCfg(
 export function resetCfg(cfg: GameProcessorAnalysisConfig): void {
     cfg.processedMoves = 0;
     cfg.processedGames = 0;
+    cfg.skippedGames = 0;
+    cfg.errors = [];
 
     for (const t of cfg.trackers.game) {
         t.resetWorkerBatch?.();
@@ -102,6 +106,8 @@ export function getCachedCfg(idxConfig: number): GameProcessorAnalysisConfig {
             trackers: { move: [], game: [] },
             processedMoves: 0,
             processedGames: 0,
+            skippedGames: 0,
+            errors: [],
         };
     }
     return cfg;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,11 @@ export type {
 } from '#types/analysis';
 export type { Game } from '#types/game';
 export type { HeatmapData, Tracker } from '#types/tracker';
+export type {
+    AnalyzeError,
+    AnalyzeErrorCode,
+    ParseError,
+    ReplayError,
+    ReplayErrorReason,
+} from '#types/errors';
+export { getAnalyzeError, isReplayError, MAX_COLLECTED_ERRORS } from '#core/analyze-errors';

--- a/src/replay/game-replayer.ts
+++ b/src/replay/game-replayer.ts
@@ -1,3 +1,5 @@
+import { collectError, createReplayError, toAbortError } from '#core/analyze-errors';
+import { isReplayFailure } from '#replay/replay-failure';
 import type { ReplayPolicy } from '#replay/replay-policy';
 import SanApplier from '#replay/san-applier';
 import SanContext from '#replay/san-context';
@@ -38,11 +40,15 @@ class GameReplayer {
      * @param game Game with `moves[]` already extracted by the PGN assembler.
      * @param analysisCfg Trackers and running processed-game/move counts.
      * @param replayPolicy `'skip'` | `'none'` | `'actions'` — see {@link ReplayPolicy}.
+     * @param gameIndex Zero-based index of this game in the processing stream.
+     * @param onError `'abort'` throws on replay failure; `'skip-game'` records and continues.
      */
     processGame(
         game: Game,
         analysisCfg: GameProcessorAnalysisConfig,
         replayPolicy: ReplayPolicy,
+        gameIndex: number,
+        onError: 'abort' | 'skip-game',
     ): void {
         for (const tracker of analysisCfg.trackers.game) {
             tracker.analyze(game);
@@ -51,8 +57,23 @@ class GameReplayer {
         const { moves } = game;
         const moveTrackers = analysisCfg.trackers.move;
 
+        let replayOk = true;
         if (replayPolicy !== 'skip') {
-            this.replayMoves(game, moveTrackers, replayPolicy);
+            replayOk = this.replayMoves(
+                game,
+                moveTrackers,
+                replayPolicy,
+                gameIndex,
+                onError,
+                analysisCfg,
+            );
+        }
+
+        if (!replayOk) {
+            for (const tracker of moveTrackers) {
+                tracker.nextGame?.();
+            }
+            return;
         }
 
         for (const tracker of moveTrackers) {
@@ -64,14 +85,25 @@ class GameReplayer {
         this.ctx.reset();
     }
 
-    /** Replay movetext onto the board; optionally emit actions for move trackers. */
-    private replayMoves(game: Game, moveTrackers: Tracker[], replayPolicy: ReplayPolicy): void {
+    /** Replay movetext onto the board; optionally emit actions for move trackers. Returns false when skipped. */
+    private replayMoves(
+        game: Game,
+        moveTrackers: Tracker[],
+        replayPolicy: ReplayPolicy,
+        gameIndex: number,
+        onError: 'abort' | 'skip-game',
+        analysisCfg: GameProcessorAnalysisConfig,
+    ): boolean {
         const { moves } = game;
         const board = this.ctx.board;
         this.ctx.activePlayer = 'w';
+        let moveIndex = 0;
+
         try {
             if (replayPolicy === 'actions') {
-                for (const san of moves) {
+                for (; moveIndex < moves.length; moveIndex += 1) {
+                    const san = moves[moveIndex];
+                    if (!san) continue;
                     const currentMoveActions = this.sanToActions.parse(san);
                     for (const tracker of moveTrackers) {
                         tracker.analyze(currentMoveActions);
@@ -80,7 +112,9 @@ class GameReplayer {
                     this.ctx.activePlayer = this.ctx.activePlayer === 'w' ? 'b' : 'w';
                 }
             } else {
-                for (const san of moves) {
+                for (; moveIndex < moves.length; moveIndex += 1) {
+                    const san = moves[moveIndex];
+                    if (!san) continue;
                     this.applier.apply(san);
                     this.ctx.activePlayer = this.ctx.activePlayer === 'w' ? 'b' : 'w';
                 }
@@ -90,8 +124,29 @@ class GameReplayer {
                 console.log(game);
                 board.printPosition();
             }
-            throw err;
+
+            this.ctx.reset();
+
+            const san = moves[moveIndex];
+            const reason = isReplayFailure(err) ? err.reason : 'IllegalMove';
+            const message = err instanceof Error ? err.message : String(err);
+            const replayError = createReplayError(
+                { gameIndex, moveIndex, san },
+                reason,
+                message,
+                err,
+            );
+
+            if (onError === 'abort') {
+                throw toAbortError(replayError);
+            }
+
+            collectError(analysisCfg.errors, replayError);
+            analysisCfg.skippedGames += 1;
+            return false;
         }
+
+        return true;
     }
 
     reset(): void {

--- a/src/replay/piece-finder.ts
+++ b/src/replay/piece-finder.ts
@@ -1,4 +1,5 @@
 import type ChessBoard from '#board/chess-board';
+import { ReplayFailure } from '#replay/replay-failure';
 import type { PieceToken, PlayerColor } from '#types/tokens';
 
 /**
@@ -14,11 +15,16 @@ DIAG[81] = 1; // Q
 DIAG[66] = 1; // B
 
 /** Thrown when no candidate piece can legally reach the target square. */
-class MoveNotFoundException extends Error {
-    constructor(token: string, player: PlayerColor, tarRow: number, tarCol: number) {
-        super(`${player}: No piece for move ${token} to (${tarRow},${tarCol}) found!`);
-        this.name = 'MoveNotFoundError';
-    }
+function moveNotFoundFailure(
+    token: string,
+    player: PlayerColor,
+    tarRow: number,
+    tarCol: number,
+): ReplayFailure {
+    return new ReplayFailure(
+        'IllegalMove',
+        `${player}: No piece for move ${token} to (${tarRow},${tarCol}) found!`,
+    );
 }
 
 /**
@@ -52,7 +58,7 @@ export default class PieceFinder {
     ): number[] {
         const [tarRow, tarCol] = toPosition;
         if (tarRow === undefined || tarCol === undefined) {
-            throw new MoveNotFoundException(token, player, -1, -1);
+            throw moveNotFoundFailure(token, player, -1, -1);
         }
 
         const validPieces = this.board.getPositionsForToken(player, token);
@@ -61,7 +67,7 @@ export default class PieceFinder {
         if (len === 1) {
             const only = validPieces[0];
             if (!only) {
-                throw new MoveNotFoundException(token, player, tarRow, tarCol);
+                throw moveNotFoundFailure(token, player, tarRow, tarCol);
             }
             return only;
         }
@@ -103,7 +109,7 @@ export default class PieceFinder {
         if (filtered.length === 1) {
             const only = filtered[0];
             if (!only) {
-                throw new MoveNotFoundException(token, player, tarRow, tarCol);
+                throw moveNotFoundFailure(token, player, tarRow, tarCol);
             }
             return only;
         }
@@ -136,7 +142,7 @@ export default class PieceFinder {
             }
         }
 
-        throw new MoveNotFoundException(token, player, tarRow, tarCol);
+        throw moveNotFoundFailure(token, player, tarRow, tarCol);
     }
 
     /**

--- a/src/replay/replay-failure.ts
+++ b/src/replay/replay-failure.ts
@@ -1,0 +1,19 @@
+import type { ReplayErrorReason } from '#types/errors';
+
+/**
+ * Internal signal thrown during SAN replay before {@link GameReplayer} adds game/move context.
+ * Not part of the public API — converted to {@link ReplayError} at the replayer boundary.
+ */
+export class ReplayFailure extends Error {
+    readonly reason: ReplayErrorReason;
+
+    constructor(reason: ReplayErrorReason, message: string) {
+        super(message);
+        this.name = 'ReplayFailure';
+        this.reason = reason;
+    }
+}
+
+export function isReplayFailure(err: unknown): err is ReplayFailure {
+    return err instanceof ReplayFailure;
+}

--- a/src/replay/san-applier.ts
+++ b/src/replay/san-applier.ts
@@ -1,4 +1,5 @@
 import { algebraicToCoordsAt } from '#board/board-coords';
+import { ReplayFailure } from '#replay/replay-failure';
 import type SanContext from '#replay/san-context';
 import type { PieceToken } from '#types/tokens';
 
@@ -88,7 +89,9 @@ export default class SanApplier {
         const board = this.ctx.board;
         const tokenChar = san.charCodeAt(0);
         const token = PIECE_TOKEN_BY_CHAR[tokenChar];
-        if (!token) return;
+        if (!token) {
+            throw new ReplayFailure('UnknownToken', `Unknown piece token in SAN: ${san}`);
+        }
 
         const end = san.length;
         const to = algebraicToCoordsAt(san, end);

--- a/src/replay/san-to-actions.ts
+++ b/src/replay/san-to-actions.ts
@@ -1,4 +1,5 @@
 import { algebraicToCoordsAt } from '#board/board-coords';
+import { ReplayFailure } from '#replay/replay-failure';
 import type SanContext from '#replay/san-context';
 import type { Action } from '#types/actions';
 import type { PieceToken } from '#types/tokens';
@@ -114,7 +115,9 @@ export default class SanToActions {
         const board = this.ctx.board;
         const tokenChar = san.charCodeAt(0);
         const token = PIECE_TOKEN_BY_CHAR[tokenChar];
-        if (!token) return actions;
+        if (!token) {
+            throw new ReplayFailure('UnknownToken', `Unknown piece token in SAN: ${san}`);
+        }
 
         const end = san.length;
         const to = algebraicToCoordsAt(san, end);

--- a/src/types/analysis-runtime.ts
+++ b/src/types/analysis-runtime.ts
@@ -1,3 +1,4 @@
+import type { AnalyzeError } from '#types/errors';
 import type { Game } from '#types/game';
 import type { Tracker, TrackerConfig } from '#types/tracker';
 
@@ -13,6 +14,8 @@ export interface GameProcessorAnalysisConfig {
     trackers: { move: Tracker[]; game: Tracker[] };
     processedMoves: number;
     processedGames: number;
+    skippedGames: number;
+    errors: AnalyzeError[];
 }
 
 /** Main-thread processor config including serializable tracker metadata for workers. */

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -1,3 +1,4 @@
+import type { AnalyzeError } from '#types/errors';
 import type { Game } from '#types/game';
 import type { Tracker } from '#types/tracker';
 
@@ -32,6 +33,11 @@ export interface AnalyzeOptions {
     runs?: AnalyzeRun[];
     /** Default: multithreaded with library defaults. `false` = single-threaded. */
     workers?: false | WorkerOptions;
+    /**
+     * How to handle replay/parse failures per game.
+     * Default `'abort'` stops on the first bad game; `'skip-game'` continues and collects errors.
+     */
+    onError?: 'abort' | 'skip-game';
 }
 
 /** Per-run counters returned from {@link analyzePGN}. */
@@ -51,6 +57,10 @@ export interface AnalyzeResult {
     movesPerSecond: number;
     /** One entry per run (length 1 when `runs` is omitted). */
     runs: AnalyzeRunResult[];
+    /** Games skipped due to replay failure when `onError: 'skip-game'`. */
+    skippedGames?: number;
+    /** First {@link MAX_COLLECTED_ERRORS} collected errors (skip-game or partial failure). */
+    errors?: AnalyzeError[];
 }
 
 /** @internal Legacy processor input — normalized from {@link AnalyzeOptions}. */
@@ -76,4 +86,6 @@ export interface MultithreadConfig {
 export interface GameAndMoveCount {
     cntGames: number;
     cntMoves: number;
+    skippedGames?: number;
+    errors?: AnalyzeError[];
 }

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,0 +1,30 @@
+export type AnalyzeErrorCode = 'replay' | 'parse';
+
+export interface AnalyzeError {
+    code: AnalyzeErrorCode;
+    message: string;
+    cause?: unknown;
+}
+
+export type ReplayErrorReason = 'IllegalMove' | 'AmbiguousSan' | 'UnknownToken';
+
+export interface ReplayError extends AnalyzeError {
+    code: 'replay';
+    gameIndex: number;
+    moveIndex?: number;
+    san?: string;
+    reason: ReplayErrorReason;
+}
+
+/** Reserved for future PGN parse failures. */
+export interface ParseError extends AnalyzeError {
+    code: 'parse';
+    gameIndex?: number;
+    reason: string;
+}
+
+export interface ReplayErrorContext {
+    gameIndex: number;
+    moveIndex?: number;
+    san?: string;
+}

--- a/src/types/worker.ts
+++ b/src/types/worker.ts
@@ -1,3 +1,4 @@
+import type { AnalyzeError } from '#types/errors';
 import type { Tracker, TrackerConfig } from '#types/tracker';
 
 /** One-time worker bootstrap: tracker class names, cfg, optional module paths. */
@@ -5,6 +6,7 @@ export interface WorkerInitData {
     configs: {
         trackerData: { name: string; cfg: TrackerConfig; path?: string }[];
     }[];
+    onError?: 'abort' | 'skip-game';
 }
 
 /** Per-batch payload sent main → worker (tracker config lives in workerData). */
@@ -22,6 +24,8 @@ export interface WorkerMessage {
     idxConfig: number;
     gameTrackers?: Tracker[];
     moveTrackers?: Tracker[];
-    /** Set when batch processing failed in the worker; main thread should abort. */
+    skippedGames?: number;
+    errors?: AnalyzeError[];
+    /** Set when batch processing failed catastrophically; main thread should abort. */
     error?: string;
 }

--- a/test/fixtures/bad-san-mid-file.pgn
+++ b/test/fixtures/bad-san-mid-file.pgn
@@ -1,0 +1,20 @@
+[Event "Rated Classical game"]
+[Site "https://lichess.org/j1dkb5dw"]
+[White "BFG9k"]
+[Black "mamalak"]
+[Result "1-0"]
+[WhiteElo "1639"]
+[BlackElo "1403"]
+[ECO "C00"]
+
+1. e4 e6 2. d4 b6 3. a3 Bb7 4. Nc3 Nh6 5. Bxh6 gxh6 6. Be2 Qg5 7. Bg4 h5 8. Nf3 Qg6 9. Nh4 Qg5 10. Bxh5 Qxh4 11. Qf3 Kd8 12. Qxf7 Nc6 13. Qe8# 1-0
+
+[Event "Bad SAN fixture"]
+[Result "*"]
+
+1. Nf9 1-0
+
+[Event "Test fixture"]
+[Result "1-0"]
+
+1. e4 e5 2. Bc4 Nc6 3. Qh5 Nf6 4. Qxf7# 1-0

--- a/test/integration/error-policy.test.ts
+++ b/test/integration/error-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'bun:test';
+import { join } from 'node:path';
+
+import { analyzePGN, getAnalyzeError, isReplayError, PieceTracker } from 'chessalyzer.js';
+
+const badSanPath = join(import.meta.dirname, '../fixtures/bad-san-mid-file.pgn');
+
+describe('Error policy', () => {
+    it('aborts on first bad game by default', async () => {
+        let caught: unknown;
+        try {
+            await analyzePGN(badSanPath, { workers: false });
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(caught).toBeDefined();
+        const analyzeError = getAnalyzeError(caught);
+        expect(analyzeError).toBeDefined();
+        expect(isReplayError(analyzeError)).toBe(true);
+        if (isReplayError(analyzeError)) {
+            expect(analyzeError.gameIndex).toBe(1);
+            expect(analyzeError.reason).toBe('IllegalMove');
+        }
+    });
+
+    it('skip-game continues with error summary (single-threaded)', async () => {
+        const data = await analyzePGN(badSanPath, { workers: false, onError: 'skip-game' });
+
+        expect(data.games).toBe(2);
+        expect(data.skippedGames).toBe(1);
+        expect(data.errors?.length).toBe(1);
+        expect(data.errors?.[0]?.code).toBe('replay');
+        if (isReplayError(data.errors?.[0])) {
+            expect(data.errors[0].gameIndex).toBe(1);
+            expect(data.errors[0].reason).toBe('IllegalMove');
+        }
+    });
+
+    it('skip-game continues with error summary (worker-parse)', async () => {
+        const data = await analyzePGN(badSanPath, { onError: 'skip-game' });
+
+        expect(data.games).toBe(2);
+        expect(data.skippedGames).toBe(1);
+        expect(data.errors?.length).toBe(1);
+    });
+
+    it('skip-game with move tracker on actions replay path', async () => {
+        const pieceTracker = new PieceTracker();
+        const data = await analyzePGN(badSanPath, {
+            trackers: [pieceTracker],
+            workers: false,
+            onError: 'skip-game',
+        });
+
+        expect(data.games).toBe(2);
+        expect(data.skippedGames).toBe(1);
+        expect(data.moves).toBe(32);
+    });
+});


### PR DESCRIPTION
Move from generic `console.error` and just throwing the first error to a better error handling strategy.
- Introduces different errors types, each with a fitting context and error message
- Adds error strategy config to either directly abort or skip games