### PR TITLE
test: add comprehensive unit tests for tracker merge and game assembly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,8 @@ trim_trailing_whitespace = false
 
 [*.yml]
 indent_size = 2
+
+[test/fixtures/crlf-endings.pgn]
+end_of_line = crlf
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+test/fixtures/crlf-endings.pgn -text

--- a/scripts/build-fixture-manifest.ts
+++ b/scripts/build-fixture-manifest.ts
@@ -1,17 +1,19 @@
 /**
- * Analyzes committed test/fixtures/*.pgn and writes test/fixtures/manifest.json.
- * Use a tested version of chessalyzer for the generation of correct expected values.
+ * Analyzes committed test/fixtures/*.pgn and merges results into test/fixtures/manifest.json.
+ * Preserves golden values and manual entries; per-fixture analyze overrides handle error fixtures.
  *
  * Run after adding or changing fixture PGNs: bun run test:build-fixtures
  *
  * Uses single-threaded mode for deterministic analysis.
  */
-import { readdir } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { analyzePGN } from '../src/index';
+import type { AnalyzeOptions } from '../src/types/analysis';
 
 const FIXTURES_DIR = new URL('../test/fixtures/', import.meta.url).pathname;
+const MANIFEST_PATH = join(FIXTURES_DIR, 'manifest.json');
 
 const descriptions: Record<string, string> = {
     'basic-normal': 'Standard complete game, single-line movetext',
@@ -26,25 +28,113 @@ const descriptions: Record<string, string> = {
     'comments-singleline': 'One game with comments, single-line movetext',
     'comments-multiline': 'One game with comments, multi-line movetext',
     'results-mix': 'Multiple games with mixed results and Elo headers for filter tests',
+    'bad-san-mid-file': 'Three games; middle game has illegal SAN (error-policy tests)',
+    'crlf-endings': 'Two complete games with CRLF line endings',
 };
+
+/** Per-fixture analyze options, or `manual` to keep the existing manifest entry unchanged. */
+const FIXTURE_ANALYZE: Record<string, AnalyzeOptions | 'manual'> = {
+    'bad-san-mid-file': { onError: 'skip-game', workers: false },
+};
+
+interface ManifestExpected {
+    cntGames: number;
+    cntMoves: number;
+    skippedGames?: number;
+}
+
+interface ManifestFixture {
+    file: string;
+    description: string;
+    expected: ManifestExpected;
+    analyzeOptions?: AnalyzeOptions;
+    golden?: Record<string, unknown>;
+}
+
+interface Manifest {
+    dir: string;
+    fixtures: Record<string, ManifestFixture>;
+}
+
+async function loadExistingManifest(): Promise<Manifest> {
+    try {
+        const text = await readFile(MANIFEST_PATH, 'utf8');
+        return JSON.parse(text) as Manifest;
+    } catch {
+        return { dir: 'test/fixtures', fixtures: {} };
+    }
+}
+
+/** Options stored in manifest (workers are always false in the build script). */
+function manifestAnalyzeOptions(
+    policy: AnalyzeOptions | 'manual' | undefined,
+): AnalyzeOptions | undefined {
+    if (!policy || policy === 'manual') return undefined;
+    const { workers: _workers, ...rest } = policy;
+    return Object.keys(rest).length > 0 ? rest : undefined;
+}
+
+const existing = await loadExistingManifest();
+const fixtures: Record<string, ManifestFixture> = {};
+let hadError = false;
 
 const files = (await readdir(FIXTURES_DIR)).filter((f) => f.endsWith('.pgn')).toSorted();
 
-const fixtures: Record<string, object> = {};
 for (const file of files) {
     const id = file.replace(/\.pgn$/, '');
     const path = join(FIXTURES_DIR, file);
+    const prior = existing.fixtures[id];
+    const policy = FIXTURE_ANALYZE[id];
 
-    const result = await analyzePGN(path, { workers: false });
+    if (policy === 'manual') {
+        if (!prior) {
+            console.error(`${id}: marked manual but missing from manifest.json`);
+            hadError = true;
+            continue;
+        }
+        fixtures[id] = { ...prior, file };
+        console.log(`${id}: kept manual entry (${prior.expected.cntGames} games)`);
+        continue;
+    }
 
-    fixtures[id] = {
-        file,
-        description: descriptions[id] ?? id,
-        expected: { cntGames: result.games, cntMoves: result.moves },
-    };
-    console.log(`${id}: ${result.games} games, ${result.moves} moves`);
+    const analyzeOpts: AnalyzeOptions = { workers: false, ...policy };
+
+    try {
+        const result = await analyzePGN(path, analyzeOpts);
+        const expected: ManifestExpected = {
+            cntGames: result.games,
+            cntMoves: result.moves,
+        };
+        if ((result.skippedGames ?? 0) > 0) {
+            expected.skippedGames = result.skippedGames;
+        }
+
+        fixtures[id] = {
+            file,
+            description: descriptions[id] ?? prior?.description ?? id,
+            expected,
+            ...(manifestAnalyzeOptions(policy) ? { analyzeOptions: manifestAnalyzeOptions(policy) } : {}),
+            ...(prior?.golden ? { golden: prior.golden } : {}),
+        };
+
+        const skipped = expected.skippedGames ? `, ${expected.skippedGames} skipped` : '';
+        console.log(`${id}: ${result.games} games, ${result.moves} moves${skipped}`);
+    } catch (err) {
+        if (prior) {
+            fixtures[id] = { ...prior, file };
+            const message = err instanceof Error ? err.message : String(err);
+            console.warn(`${id}: analyze failed, kept existing entry (${message})`);
+            continue;
+        }
+
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`${id}: analyze failed with no existing manifest entry (${message})`);
+        hadError = true;
+    }
 }
 
-const manifest = { dir: 'test/fixtures', fixtures };
-await Bun.write(join(FIXTURES_DIR, 'manifest.json'), JSON.stringify(manifest, null, 4) + '\n');
+if (hadError) process.exit(1);
+
+const manifest: Manifest = { dir: 'test/fixtures', fixtures };
+await Bun.write(MANIFEST_PATH, JSON.stringify(manifest, null, 4) + '\n');
 console.log('\nWrote test/fixtures/manifest.json');

--- a/src/core/__tests__/tracker-merge.test.ts
+++ b/src/core/__tests__/tracker-merge.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'bun:test';
+
+import { createWorkerResultHandler } from '#core/tracker-merge';
+import TileTracker from '#tracker/tile/tile-tracker-base';
+import type { GameProcessorAnalysisConfigFull } from '#types/analysis-runtime';
+import type { WorkerMessage } from '#types/worker';
+
+import CustomGameTracker from '../../../test/fixtures/custom-game-tracker';
+
+function baseConfig(
+    overrides?: Partial<GameProcessorAnalysisConfigFull>,
+): GameProcessorAnalysisConfigFull {
+    return {
+        config: {
+            hasFilter: false,
+            filter: () => true,
+            cntGames: Infinity,
+        },
+        trackerData: [],
+        cntReadGames: 0,
+        isDone: false,
+        trackers: { move: [], game: [] },
+        processedMoves: 0,
+        processedGames: 0,
+        skippedGames: 0,
+        errors: [],
+        ...overrides,
+    };
+}
+
+describe('tracker merge', () => {
+    describe('TileTracker.merge', () => {
+        it('sums counters and tile stats from a partial batch', () => {
+            const main = new TileTracker();
+            const batch = new TileTracker();
+
+            main.cntMovesTotal = 10;
+            batch.cntMovesTotal = 7;
+            main.tiles[4][4].w.movedTo = 3;
+            batch.tiles[4][4].w.movedTo = 2;
+
+            main.merge(batch);
+
+            expect(main.cntMovesTotal).toBe(17);
+            expect(main.tiles[4][4].w.movedTo).toBe(5);
+        });
+    });
+
+    describe('CustomGameTracker.merge', () => {
+        it('sums wins and game counts from a partial batch', () => {
+            const main = new CustomGameTracker();
+            const batch = new CustomGameTracker();
+
+            main.wins = [2, 1, 3];
+            main.cntGames = 6;
+            batch.wins = [1, 0, 2];
+            batch.cntGames = 3;
+
+            main.merge(batch);
+
+            expect(main.wins).toEqual([3, 1, 5]);
+            expect(main.cntGames).toBe(9);
+        });
+    });
+
+    describe('createWorkerResultHandler', () => {
+        it('routes result.error to onFatal', () => {
+            const cfg = baseConfig();
+            let fatal: Error | undefined;
+
+            const handler = createWorkerResultHandler([cfg], (err) => {
+                fatal = err;
+            });
+
+            const result: WorkerMessage = {
+                idxConfig: 0,
+                cntGames: 0,
+                cntMoves: 0,
+                error: 'Unknown tracker "DoesNotExist"',
+            };
+
+            handler(null, result);
+
+            expect(fatal).toBeInstanceOf(Error);
+            expect(fatal?.message).toBe('Unknown tracker "DoesNotExist"');
+        });
+
+        it('merges worker batch counters and tracker state', () => {
+            const mainTracker = new CustomGameTracker();
+            const batchTracker = new CustomGameTracker();
+            batchTracker.wins = [1, 0, 1];
+            batchTracker.cntGames = 2;
+
+            const cfg = baseConfig({
+                trackers: { game: [mainTracker], move: [] },
+                config: { hasFilter: false, filter: () => true, cntGames: 10 },
+            });
+
+            const handler = createWorkerResultHandler([cfg], () => {
+                throw new Error('onFatal should not run');
+            });
+
+            handler(null, {
+                idxConfig: 0,
+                cntGames: 2,
+                cntMoves: 40,
+                gameTrackers: [batchTracker],
+            });
+
+            expect(cfg.processedGames).toBe(2);
+            expect(cfg.processedMoves).toBe(40);
+            expect(mainTracker.cntGames).toBe(2);
+            expect(mainTracker.wins).toEqual([1, 0, 1]);
+        });
+    });
+});

--- a/src/pgn/__tests__/game-assembler.test.ts
+++ b/src/pgn/__tests__/game-assembler.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+import { GameAssembler, parseGamesFromLines } from '#pgn/game-assembler';
+
+import { fixturePath } from '../../../test/helpers/fixtures';
+
+function linesFromFixture(id: 'lichess-headers' | 'corrupt'): string[] {
+    return readFileSync(fixturePath(id), 'utf8').split('\n');
+}
+
+describe('GameAssembler', () => {
+    it('reads headers when readInHeader is true', () => {
+        const games = parseGamesFromLines(linesFromFixture('lichess-headers'), {
+            readInHeader: true,
+        });
+
+        expect(games).toHaveLength(1);
+        expect(games[0]?.White).toBe('TestWhite');
+        expect(games[0]?.Black).toBe('TestBlack');
+        expect(games[0]?.Result).toBe('1-0');
+        expect(games[0]?.ECO).toBe('C20');
+    });
+
+    it('ignores headers when readInHeader is false', () => {
+        const games = parseGamesFromLines(linesFromFixture('lichess-headers'), {
+            readInHeader: false,
+        });
+
+        expect(games).toHaveLength(1);
+        expect(games[0]?.White).toBeUndefined();
+        expect(games[0]?.Result).toBe('1-0');
+        expect(games[0]?.moves.length).toBeGreaterThan(0);
+    });
+
+    it('drops an incomplete trailing game', () => {
+        const games = parseGamesFromLines(linesFromFixture('corrupt'), { readInHeader: true });
+
+        expect(games).toHaveLength(1);
+        expect(games[0]?.Result).toBe('1-0');
+    });
+
+    it('stops at maxGames', () => {
+        const lines = [
+            '[Event "One"]',
+            '',
+            '1. e4 1-0',
+            '',
+            '[Event "Two"]',
+            '',
+            '1. d4 1-0',
+            '',
+            '[Event "Three"]',
+            '',
+            '1. c4 1-0',
+        ];
+
+        const games = parseGamesFromLines(lines, { readInHeader: false, maxGames: 2 });
+
+        expect(games).toHaveLength(2);
+        expect(games[0]?.moves[0]).toBe('e4');
+        expect(games[1]?.moves[0]).toBe('d4');
+    });
+
+    it('returns null until a game completes', () => {
+        const assembler = new GameAssembler({ readInHeader: true });
+
+        expect(assembler.processLine('[Event "x"]')).toBeNull();
+        expect(assembler.processLine('')).toBeNull();
+        expect(assembler.processLine('1. e4 e5')).toBeNull();
+
+        const completed = assembler.processLine('2. Nf3 1-0');
+        expect(completed).not.toBeNull();
+        expect(completed?.moves).toEqual(['e4', 'e5', 'Nf3']);
+        expect(completed?.Result).toBe('1-0');
+    });
+});

--- a/src/pgn/__tests__/line-reader.test.ts
+++ b/src/pgn/__tests__/line-reader.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'bun:test';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { readLinesFast } from '#pgn/line-reader';
 
+const FIXTURES_DIR = join(new URL('../../../test/fixtures', import.meta.url).pathname);
+const CRLF_FIXTURE = join(FIXTURES_DIR, 'crlf-endings.pgn');
 const TMP_DIR = join(new URL('../../../test/.tmp', import.meta.url).pathname);
 
 async function writeTmpPgn(name: string, content: string): Promise<string> {
@@ -37,5 +39,28 @@ describe('readLinesFast', () => {
         const lines = await collectLines(path);
 
         expect(lines).toEqual(['a', '', 'b', '']);
+    });
+
+    it('strips CRLF line endings', async () => {
+        const raw = await readFile(CRLF_FIXTURE);
+        expect(raw.includes('\r\n')).toBe(true);
+
+        const lines = await collectLines(CRLF_FIXTURE);
+
+        expect(lines.every((line) => !line.includes('\r'))).toBe(true);
+        expect(lines).toEqual([
+            '[Event "CRLF test"]',
+            '[Result "1-0"]',
+            '',
+            '1. e4 e5 2. Nf3 1-0',
+            '',
+            '',
+            '[Event "CRLF test multiline"]',
+            '[Result "1-0"]',
+            '',
+            '1. e4 1... e5 ',
+            '2. Nf3 1-0',
+            '',
+        ]);
     });
 });

--- a/src/pgn/__tests__/pgn-chunk.test.ts
+++ b/src/pgn/__tests__/pgn-chunk.test.ts
@@ -76,6 +76,14 @@ describe('readPgnChunks', () => {
         if (!chunk) return;
         expect(chunkEndsWithCompleteGame(chunk.text.split('\n'))).toBe(true);
     });
+
+    it('emits a complete game before an incomplete trailing game with default chunk size', async () => {
+        const chunks = await collectChunks(fixturePath('corrupt'), {});
+        expect(chunks).toHaveLength(1);
+        const games = parseGamesFromLines(chunks[0]!.text.split('\n'), { readInHeader: true });
+        expect(games).toHaveLength(1);
+        expect(games[0]?.Result).toBe('1-0');
+    });
 });
 
 describe('chunkEndsWithCompleteGame', () => {
@@ -85,5 +93,18 @@ describe('chunkEndsWithCompleteGame', () => {
 
     it('returns false when the chunk ends mid-game', () => {
         expect(chunkEndsWithCompleteGame(['[Event "x"]', '', '1. e4 e5'])).toBe(false);
+    });
+
+    it('finds the last complete game when a trailing game is incomplete', () => {
+        const lines = [
+            '[Event "Complete"]',
+            '',
+            '1. e4 1-0',
+            '',
+            '[Event "Incomplete"]',
+            '',
+            '1. d4 d5',
+        ];
+        expect(chunkEndsWithCompleteGame(lines)).toBe(false);
     });
 });

--- a/src/pgn/line-reader.ts
+++ b/src/pgn/line-reader.ts
@@ -125,6 +125,12 @@ class FixedQueue<T> {
     }
 }
 
+/** Strip a trailing CR from CRLF (or rare CR-only) line endings. */
+function stripCarriageReturn(line: string): string {
+    const last = line.charCodeAt(line.length - 1);
+    return last === 13 ? line.slice(0, -1) : line;
+}
+
 /**
  * Custom line reader that reads lines faster than the native readline module.
  * @param file - The file to read.
@@ -151,7 +157,7 @@ export function readLinesFast(file: string): AsyncIterable<string> {
             // If the file was fully read, return the leftover line.
             if (result.done) {
                 if (leftover !== '') {
-                    line = leftover;
+                    line = stripCarriageReturn(leftover);
                     leftover = '';
                 }
                 break;
@@ -169,7 +175,7 @@ export function readLinesFast(file: string): AsyncIterable<string> {
             if (!endsWithNewline) leftover = parts.pop() ?? '';
 
             // Add the parts to the cache.
-            cache.push(...parts);
+            cache.push(...parts.map(stripCarriageReturn));
 
             // Try to get a line from the cache again.
             line = cache.shift();

--- a/src/pgn/pgn-chunks.ts
+++ b/src/pgn/pgn-chunks.ts
@@ -52,7 +52,7 @@ function findLastCompleteGameLineIndex(lines: string[]): number {
         const line = lines[i];
         if (line === undefined || line === '') continue;
         if (line.startsWith('[')) continue;
-        return isGameResultLine(stripComments(line)) ? i : -1;
+        if (isGameResultLine(stripComments(line))) return i;
     }
     return -1;
 }

--- a/src/replay/__tests__/game-replayer.test.ts
+++ b/src/replay/__tests__/game-replayer.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+import type ChessBoard from '#board/chess-board';
+import { parseGamesFromLines } from '#pgn/game-assembler';
+import GameReplayer from '#replay/game-replayer';
+import SanApplier from '#replay/san-applier';
+import SanContext from '#replay/san-context';
+import { MoveTracker } from '#tracker/base-tracker';
+import type { Action } from '#types/actions';
+import type { GameProcessorAnalysisConfig } from '#types/analysis-runtime';
+import type { Game } from '#types/game';
+
+import { fixturePath } from '../../../test/helpers/fixtures';
+
+function emptyCfg(): GameProcessorAnalysisConfig {
+    return {
+        trackers: { move: [], game: [] },
+        processedMoves: 0,
+        processedGames: 0,
+        skippedGames: 0,
+        errors: [],
+    };
+}
+
+function game(moves: string[], result = '1-0'): Game {
+    return { moves, Result: result };
+}
+
+/** Same SanApplier path GameReplayer uses for `'none'` policy. */
+function boardAfterSans(moves: string[]): ChessBoard {
+    const ctx = new SanContext();
+    const applier = new SanApplier(ctx);
+    for (const san of moves) {
+        applier.apply(san);
+        ctx.activePlayer = ctx.activePlayer === 'w' ? 'b' : 'w';
+    }
+    return ctx.board;
+}
+
+describe('GameReplayer', () => {
+    describe('processGame counters and policy', () => {
+        it('counts processed games and moves', () => {
+            const replayer = new GameReplayer();
+            const cfg = emptyCfg();
+
+            replayer.processGame(game(['e4', 'e5', 'Nf3']), cfg, 'none', 0, 'abort');
+
+            expect(cfg.processedGames).toBe(1);
+            expect(cfg.processedMoves).toBe(3);
+        });
+
+        it('feeds move trackers on the actions replay path', () => {
+            const replayer = new GameReplayer();
+            const cfg = emptyCfg();
+
+            class ActionCounter extends MoveTracker {
+                actionCount = 0;
+
+                trackMoves(actions: Action[]) {
+                    this.actionCount += actions.length;
+                }
+
+                merge() {}
+            }
+
+            const counter = new ActionCounter();
+            cfg.trackers.move.push(counter);
+
+            replayer.processGame(game(['e4', 'e5']), cfg, 'actions', 0, 'abort');
+
+            expect(counter.actionCount).toBe(2);
+            expect(cfg.processedMoves).toBe(2);
+        });
+
+        it('skip-game records replay failures without counting the game', () => {
+            const replayer = new GameReplayer();
+            const cfg = emptyCfg();
+
+            replayer.processGame(game(['Nf9']), cfg, 'none', 0, 'skip-game');
+
+            expect(cfg.processedGames).toBe(0);
+            expect(cfg.skippedGames).toBe(1);
+            expect(cfg.errors).toHaveLength(1);
+        });
+
+        it('reset restores the starting position', () => {
+            const replayer = new GameReplayer();
+            const cfg = emptyCfg();
+
+            replayer.processGame(game(['e4']), cfg, 'none', 0, 'abort');
+            replayer.reset();
+
+            expect(replayer.board.getPieceAt(6, 4)?.name).toBe('Pe');
+            expect(replayer.board.getPieceAt(4, 4)).toBeNull();
+        });
+    });
+
+    describe('trust-mode board state (none policy / SanApplier path)', () => {
+        it('replays a basic SAN sequence', () => {
+            const board = boardAfterSans(['e4', 'e5', 'Nf3']);
+
+            expect(board.getPieceAt(4, 4)?.name).toBe('Pe');
+            expect(board.getPieceAt(3, 4)?.name).toBe('Pe');
+            const knight = board.getPieceAt(5, 5);
+            expect(knight?.name?.charAt(0)).toBe('N');
+            expect(knight?.color).toBe('w');
+        });
+
+        it('replays captures', () => {
+            const board = boardAfterSans(['e4', 'e5', 'Nf3', 'Nc6', 'Bc4', 'Bc5', 'b4', 'Bxb4']);
+
+            const bishop = board.getPieceAt(4, 1);
+            expect(bishop?.name?.charAt(0)).toBe('B');
+            expect(bishop?.color).toBe('b');
+        });
+
+        it('replays castling', () => {
+            const board = boardAfterSans(['e4', 'e5', 'Nf3', 'Nc6', 'Bc4', 'Bc5', 'O-O']);
+
+            expect(board.getPieceAt(7, 6)?.name).toBe('Ke');
+            expect(board.getPieceAt(7, 5)?.name).toBe('Rh');
+            expect(board.getPieceAt(7, 4)).toBeNull();
+        });
+
+        it('replays pawn promotion', () => {
+            const [promoGame] = parseGamesFromLines(
+                readFileSync(fixturePath('promotion'), 'utf8').split('\n'),
+                { readInHeader: false },
+            );
+            const board = boardAfterSans(promoGame?.moves ?? []);
+
+            const queen = board.getPieceAt(0, 6);
+            expect(queen?.name?.charAt(0)).toBe('Q');
+            expect(queen?.color).toBe('w');
+        });
+    });
+});

--- a/test/README.md
+++ b/test/README.md
@@ -61,8 +61,10 @@ Corpus tests use `describe.skip` when `test/corpus/asorted-games.pgn` is missing
 ```sh
 bun run build                # required before integration tests (CI runs this automatically)
 bun test                     # fixtures + unit tests (CI default)
-bun run test:build-fixtures  # regenerate manifest after fixture changes
+bun run test:build-fixtures  # merge-update manifest after fixture changes (preserves golden)
 ```
+
+`test:build-fixtures` re-analyzes each `test/fixtures/*.pgn` and updates `expected` counts. It preserves `golden` blocks and uses per-fixture `analyzeOptions` overrides (see `FIXTURE_ANALYZE` in `scripts/build-fixture-manifest.ts`) for error-policy fixtures like `bad-san-mid-file`.
 
 CI (`.github/workflows/ci.yml`) runs `bun run build` then `bun test`. Corpus tests are included in `bun test` but skip when the local corpus file is absent.
 

--- a/test/README.md
+++ b/test/README.md
@@ -12,11 +12,19 @@ test/helpers/               Shared test utilities
 
 ### Colocated unit tests
 
-Module-specific tests live next to the code they exercise (e.g. `src/pgn/__tests__/pgn-chunk.test.js` tests `line-reader.ts` and `game-assembler.ts`). This makes it obvious which source file a failure relates to.
+Module-specific tests live next to the code they exercise (e.g. `src/pgn/__tests__/pgn-chunk.test.ts` tests chunk alignment and parsing). This makes it obvious which source file a failure relates to.
 
 ### Integration tests
 
 Tests that run the full `analyzePGN` pipeline stay in `test/integration/` because they span parsing, workers, and trackers — not a single module.
+
+| File                     | Focus                                           |
+| ------------------------ | ----------------------------------------------- |
+| `fixtures.test.ts`       | Small PGN fixtures, filters, TileTracker golden |
+| `workers.test.ts`        | WorkerPool error propagation, MT abort          |
+| `custom-tracker.test.ts` | Custom tracker + `workerModule` in MT mode      |
+| `error-policy.test.ts`   | `onError: 'abort'` / `'skip-game'`              |
+| `corpus.test.ts`         | Optional large-file golden regression           |
 
 ### Fixtures vs corpus
 
@@ -27,11 +35,37 @@ Tests that run the full `analyzePGN` pipeline stay in `test/integration/` becaus
 | CI       | always runs               | skipped without local file |
 | Purpose  | format/edge-case coverage | golden regression at scale |
 
+Corpus tests use `describe.skip` when `test/corpus/asorted-games.pgn` is missing locally.
+
+## Coverage matrix
+
+| Area                     | Single-threaded | Multithreaded | Where                                        |
+| ------------------------ | --------------- | ------------- | -------------------------------------------- |
+| Basic parse counts       | yes             | yes           | `fixtures.test.ts`, `corpus.test.ts`         |
+| Filter / maxGames        | yes             | yes           | `fixtures.test.ts`, `corpus.test.ts`         |
+| Multi-run                | —               | yes           | `fixtures.test.ts`                           |
+| GameTracker golden       | yes             | yes           | `corpus.test.ts` (corpus only)               |
+| PieceTracker golden      | yes             | yes           | `corpus.test.ts` (corpus only)               |
+| TileTracker golden       | yes             | yes           | `fixtures.test.ts` (`en-passant.pgn`)        |
+| Custom tracker MT        | —               | yes           | `custom-tracker.test.ts`                     |
+| Replay unit              | yes             | —             | `src/replay/__tests__/game-replayer.test.ts` |
+| Error skip-game          | yes             | yes           | `error-policy.test.ts`                       |
+| Error abort              | yes             | yes           | `error-policy.test.ts`, `workers.test.ts`    |
+| Worker error propagation | —               | yes           | `workers.test.ts`, `tracker-merge.test.ts`   |
+| Tracker merge unit       | —               | —             | `src/core/__tests__/tracker-merge.test.ts`   |
+
+**Corpus-only gaps:** GameTracker ECO totals, PieceTracker heatmaps, and large-scale filter counts require `test/corpus/asorted-games.pgn`. TileTracker castling double-count (two move actions per castle) is documented in fixture golden tests.
+
 ## Commands
 
 ```sh
-bun test                      # fixtures + unit tests (CI default)
-bun run test:corpus           # include corpus regression
-bun run test:fetch-corpus     # copy large PGNs into test/corpus/
-bun run test:build-fixtures   # regenerate manifest after fixture changes
+bun run build                # required before integration tests (CI runs this automatically)
+bun test                     # fixtures + unit tests (CI default)
+bun run test:build-fixtures  # regenerate manifest after fixture changes
 ```
+
+CI (`.github/workflows/ci.yml`) runs `bun run build` then `bun test`. Corpus tests are included in `bun test` but skip when the local corpus file is absent.
+
+## Optional local checks
+
+- **Perf regression:** `npm run bench:perf` when a large PGN is available under `pgn/` (not run in default CI)

--- a/test/fixtures/crlf-endings.pgn
+++ b/test/fixtures/crlf-endings.pgn
@@ -1,0 +1,11 @@
+[Event "CRLF test"]
+[Result "1-0"]
+
+1. e4 e5 2. Nf3 1-0
+
+
+[Event "CRLF test multiline"]
+[Result "1-0"]
+
+1. e4 1... e5 
+2. Nf3 1-0

--- a/test/fixtures/manifest.json
+++ b/test/fixtures/manifest.json
@@ -1,6 +1,18 @@
 {
     "dir": "test/fixtures",
     "fixtures": {
+        "bad-san-mid-file": {
+            "file": "bad-san-mid-file.pgn",
+            "description": "Three games; middle game has illegal SAN (error-policy tests)",
+            "expected": {
+                "cntGames": 2,
+                "cntMoves": 32,
+                "skippedGames": 1
+            },
+            "analyzeOptions": {
+                "onError": "skip-game"
+            }
+        },
         "basic-normal": {
             "file": "basic-normal.pgn",
             "description": "Standard complete game, single-line movetext",
@@ -39,6 +51,14 @@
             "expected": {
                 "cntGames": 1,
                 "cntMoves": 15
+            }
+        },
+        "crlf-endings": {
+            "file": "crlf-endings.pgn",
+            "description": "Two complete games with CRLF line endings",
+            "expected": {
+                "cntGames": 2,
+                "cntMoves": 6
             }
         },
         "draw": {

--- a/test/fixtures/manifest.json
+++ b/test/fixtures/manifest.json
@@ -55,6 +55,12 @@
             "expected": {
                 "cntGames": 1,
                 "cntMoves": 49
+            },
+            "golden": {
+                "tileTracker": {
+                    "cntMovesTotal": 51,
+                    "e4TileOccAll": 62.745098039215684
+                }
             }
         },
         "lichess-headers": {

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -25,7 +25,8 @@ export interface TileTrackerGolden {
 export interface FixtureEntry {
     file: string;
     description: string;
-    expected: { cntGames: number; cntMoves: number };
+    expected: { cntGames: number; cntMoves: number; skippedGames?: number };
+    analyzeOptions?: { onError?: 'abort' | 'skip-game' };
     golden?: {
         tileTracker?: TileTrackerGolden;
     };

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -17,7 +17,7 @@ const TMP_DIR = join(TEST_DIR, '.tmp');
 
 export type FixtureId = keyof typeof manifest.fixtures;
 
-export interface TileTrackerGolden {
+interface TileTrackerGolden {
     cntMovesTotal: number;
     e4TileOccAll: number;
 }

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -17,6 +17,20 @@ const TMP_DIR = join(TEST_DIR, '.tmp');
 
 export type FixtureId = keyof typeof manifest.fixtures;
 
+export interface TileTrackerGolden {
+    cntMovesTotal: number;
+    e4TileOccAll: number;
+}
+
+export interface FixtureEntry {
+    file: string;
+    description: string;
+    expected: { cntGames: number; cntMoves: number };
+    golden?: {
+        tileTracker?: TileTrackerGolden;
+    };
+}
+
 /** Absolute path to a committed fixture PGN. */
 export function fixturePath(id: FixtureId): string {
     const entry = manifest.fixtures[id];
@@ -27,6 +41,13 @@ export function fixturePath(id: FixtureId): string {
 /** Expected game/move counts from test/fixtures/manifest.json. */
 export function fixtureExpected(id: FixtureId) {
     return manifest.fixtures[id].expected;
+}
+
+/** Full manifest entry for a fixture (includes optional golden values). */
+export function getFixtureEntry(id: FixtureId): FixtureEntry {
+    const entry = manifest.fixtures[id];
+    if (!entry) throw new Error(`Unknown fixture id: ${id}`);
+    return entry as FixtureEntry;
 }
 
 /**

--- a/test/integration/corpus.test.ts
+++ b/test/integration/corpus.test.ts
@@ -250,6 +250,6 @@ if (corpusAvailable) {
 } else {
     describe.skip('Corpus regression (asorted)', () => {});
     console.warn(
-        'Skipping corpus tests: asorted-games.pgn not found. Run: bun run test:fetch-corpus',
+        'Skipping corpus tests: asorted-games.pgn not found in test/corpus/.',
     );
 }

--- a/test/integration/corpus.test.ts
+++ b/test/integration/corpus.test.ts
@@ -249,7 +249,5 @@ if (corpusAvailable) {
     });
 } else {
     describe.skip('Corpus regression (asorted)', () => {});
-    console.warn(
-        'Skipping corpus tests: asorted-games.pgn not found in test/corpus/.',
-    );
+    console.warn('Skipping corpus tests: asorted-games.pgn not found in test/corpus/.');
 }

--- a/test/integration/fixtures.test.ts
+++ b/test/integration/fixtures.test.ts
@@ -24,13 +24,20 @@ describe('Fixtures', () => {
             let data: AnalyzeResult;
 
             beforeAll(async () => {
-                data = await analyzePGN(fixturePath(id), { workers: false });
+                const entry = getFixtureEntry(id);
+                data = await analyzePGN(fixturePath(id), {
+                    workers: false,
+                    ...entry.analyzeOptions,
+                });
             });
 
             it('parses the expected number of games and moves', () => {
-                const expected = fixtureExpected(id);
+                const expected = getFixtureEntry(id).expected;
                 expect(data.games).toBe(expected.cntGames);
                 expect(data.moves).toBe(expected.cntMoves);
+                if (expected.skippedGames !== undefined) {
+                    expect(data.skippedGames).toBe(expected.skippedGames);
+                }
             });
         });
     }

--- a/test/integration/fixtures.test.ts
+++ b/test/integration/fixtures.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeAll, afterAll, expect } from 'bun:test';
 
-import { analyzePGN, GameTracker, PieceTracker } from 'chessalyzer.js';
+import { analyzePGN, GameTracker, PieceTracker, TileTracker } from 'chessalyzer.js';
 
 import type { AnalyzeResult } from '../../src/types/analysis';
 import type { Game } from '../../src/types/game';
@@ -9,6 +9,7 @@ import {
     cleanupTmpPgns,
     fixtureExpected,
     fixturePath,
+    getFixtureEntry,
     repeatPgn,
 } from '../helpers/fixtures';
 
@@ -141,6 +142,40 @@ describe('Fixtures', () => {
             });
             expect(data.games).toBe(1);
             expect(data.moves).toBeGreaterThan(0);
+        });
+    });
+
+    describe('TileTracker golden (en-passant)', () => {
+        const golden = getFixtureEntry('en-passant').golden?.tileTracker;
+        if (!golden) throw new Error('en-passant fixture missing tileTracker golden values');
+
+        for (const [mode, workers] of [
+            ['single-threaded', false],
+            ['multithreaded', undefined],
+        ] as const) {
+            it(`matches golden values (${mode})`, async () => {
+                const tileTracker = new TileTracker();
+                const data = await analyzePGN(fixturePath('en-passant'), {
+                    trackers: [tileTracker],
+                    ...(workers === false ? { workers: false } : {}),
+                });
+
+                expect(data.games).toBe(1);
+                expect(tileTracker.cntMovesTotal).toBe(golden.cntMovesTotal);
+                const heat = tileTracker.generateHeatmap('TILE_OCC_ALL', 'e4');
+                expect(heat.map[4]?.[4]).toBe(golden.e4TileOccAll);
+            });
+        }
+
+        it('counts castling as two move actions (known behavior)', async () => {
+            const tileTracker = new TileTracker();
+            await analyzePGN(fixturePath('en-passant'), {
+                trackers: [tileTracker],
+                workers: false,
+            });
+
+            expect(tileTracker.cntMovesTotal).toBe(golden.cntMovesTotal);
+            expect(fixtureExpected('en-passant').cntMoves).toBe(49);
         });
     });
 });

--- a/test/integration/workers.test.ts
+++ b/test/integration/workers.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, afterEach } from 'bun:test';
 import { join } from 'node:path';
 
-import { analyzePGN } from 'chessalyzer.js';
+import { analyzePGN, TileTracker } from 'chessalyzer.js';
 
 import WorkerPool from '../../src/core/worker-pool';
+import { fixturePath } from '../helpers/fixtures';
 
 const workerPath = join(import.meta.dirname, '../../lib/chess-worker.js');
 const badSanPath = join(import.meta.dirname, '../fixtures/bad-san-mid-file.pgn');
+const corruptPath = fixturePath('corrupt');
 
 const minimalChunkBytes = new TextEncoder().encode('[Event "t"]\n\n1. e4 1-0\n');
 
@@ -75,6 +77,20 @@ describe('Workers', () => {
 
             expect(caught).toBeDefined();
             expect(caught).toBeInstanceOf(Error);
+        });
+
+        it('processes corrupt.pgn with an incomplete trailing game without hanging', async () => {
+            const tileTracker = new TileTracker();
+            const data = await Promise.race([
+                analyzePGN(corruptPath, { trackers: [tileTracker] }),
+                new Promise<never>((_, reject) =>
+                    setTimeout(() => reject(new Error('analyzePGN timed out')), 10_000),
+                ),
+            ]);
+
+            expect(data.games).toBe(1);
+            expect(data.moves).toBe(15);
+            expect(tileTracker.cntMovesTotal).toBeGreaterThan(0);
         });
     });
 });

--- a/test/integration/workers.test.ts
+++ b/test/integration/workers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { join } from 'node:path';
+
+import { analyzePGN } from 'chessalyzer.js';
+
+import WorkerPool from '../../src/core/worker-pool';
+
+const workerPath = join(import.meta.dirname, '../../lib/chess-worker.js');
+const badSanPath = join(import.meta.dirname, '../fixtures/bad-san-mid-file.pgn');
+
+const minimalChunkBytes = new TextEncoder().encode('[Event "t"]\n\n1. e4 1-0\n');
+
+function runTaskWithTimeout(
+    pool: WorkerPool,
+    task: Parameters<WorkerPool['runTask']>[0],
+    timeoutMs: number,
+): Promise<{ err: Error | null; result: import('../../src/types/worker').WorkerMessage | null }> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(
+            () => reject(new Error('WorkerPool callback timed out')),
+            timeoutMs,
+        );
+
+        pool.runTask(task, (err, result) => {
+            clearTimeout(timer);
+            resolve({ err, result });
+        });
+    });
+}
+
+describe('Workers', () => {
+    describe('WorkerPool error propagation', () => {
+        let pool: WorkerPool | undefined;
+
+        afterEach(async () => {
+            await pool?.close();
+            pool = undefined;
+        });
+
+        it('returns batch errors to the callback instead of hanging', async () => {
+            pool = new WorkerPool(1, workerPath, {
+                configs: [
+                    {
+                        trackerData: [
+                            { id: 'DoesNotExist', cfg: { profilingActive: false }, path: '' },
+                        ],
+                    },
+                ],
+            });
+
+            const { err, result } = await runTaskWithTimeout(
+                pool,
+                {
+                    pgnChunkBytes: minimalChunkBytes,
+                    idxConfig: 0,
+                    readInHeader: false,
+                },
+                10_000,
+            );
+
+            expect(err).toBeInstanceOf(Error);
+            expect(err?.message).toContain('Unknown tracker');
+            expect(result === null || result?.error !== undefined || err !== null).toBe(true);
+        });
+    });
+
+    describe('analyzePGN multithreaded', () => {
+        it('aborts on first bad game by default', async () => {
+            let caught: unknown;
+            try {
+                await analyzePGN(badSanPath);
+            } catch (err) {
+                caught = err;
+            }
+
+            expect(caught).toBeDefined();
+            expect(caught).toBeInstanceOf(Error);
+        });
+    });
+});


### PR DESCRIPTION
- Introduced new unit tests for `TileTracker` and `CustomGameTracker` to validate the merging of counters and stats from partial batches.
- Added tests for `createWorkerResultHandler` to ensure proper error handling and merging of worker results.
- Implemented tests for `GameAssembler` to verify header reading, game completion, and handling of incomplete games.
- Enhanced `GameReplayer` tests to cover game processing, move tracking, and board state restoration.
- Updated documentation in `README.md` to reflect new test structures and coverage details.
- Added tests and handling for CRLF endings
- Fix worker hang on corrupt file and added regression test