### PR TITLE
perf(line-reader): switch to event-based line reader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Chessalyzer.js parses large PGN databases and runs user-defined **trackers** ove
 
 **Pipeline (high level):**
 
-1. **Line reading** — `readLinesFast` in `src/pgn/line-reader.ts` and `readPgnChunks` in `src/pgn/pgn-chunks.ts` stream the file with minimal overhead.
+1. **Line reading** — `readLines` / `openLineStream` in `src/pgn/line-reader.ts` (readline `'line'` events) and `readPgnChunks` in `src/pgn/pgn-chunks.ts` stream the file with minimal overhead.
 2. **Chunking (multithreaded mode)** — the main thread splits the PGN into byte-sized chunks aligned to complete games and dispatches them to workers.
 3. **Assemble** — workers tokenize movetext and build game objects (`src/pgn/`).
 4. **Replay** — SAN is applied to a board (`src/replay/`), with explicit policy `'none' | 'actions'` (or `'skip'` when gated).
@@ -39,7 +39,7 @@ Chessalyzer.js parses large PGN databases and runs user-defined **trackers** ove
 
 `analyzePGN` picks one of two internal paths:
 
-1. **Single-threaded** — `workers: false`. Main thread: `readLinesFast` → `GameAssembler` → `GameReplayer` (policy from `resolveReplayPolicy`).
+1. **Single-threaded** — `workers: false`. Main thread: `readLines` → `GameAssembler` → `GameReplayer` (policy from `resolveReplayPolicy`).
 2. **Multithreaded (worker-chunk)** — default. Main thread: `readPgnChunks` → workers assemble once per chunk. Without a `filter`, workers also replay and merge tracker state. With a `filter`, workers return parsed games and the main thread applies the JS predicate and replay (trackers stay on the main thread for that run). `maxGames` is enforced on workers when there is no filter, and on the main thread after filtering when there is.
 
 **Replay policy:** `resolveReplayPolicy(hasMoveTrackers)` returns `'skip' | 'none' | 'actions'`. Count-only runs (no move trackers) skip board replay by default (`SKIP_REPLAY_WITHOUT_MOVE_TRACKERS = true` in `src/replay/replay-policy.ts`). Move trackers always get `'actions'`; game-only trackers get `'none'` when replay runs. Flip the constant to `false` to always replay SAN (e.g. to surface replay errors on count-only runs).
@@ -52,7 +52,7 @@ Examples of deliberate choices:
 
 - **Manual `Symbol.asyncIterator` instead of `async function*`** in `readPgnChunks` (~7–10% faster than async generators on large files).
 - **`Array.concat` vs `push`** in specific hot loops where benchmarks showed a win. Run `npm run bench:atomic -- array` before changing append patterns.
-- **Fixed-size circular-buffer queue** in `readLinesFast` (Node-style `FixedQueue`) to avoid shift-from-array costs.
+- **Readline `'line'` events instead of `for await`** in `openLineStream` / `readLines` — sync push handlers beat async-iterator pull on large PGNs; `await` only at chunk boundaries in `readPgnChunks`. See `bench/exploratory/line-reader-readline.ts`. Do not reintroduce per-line async iteration for “cleaner” ergonomics.
 - **Worker-side parsing** with transferable UTF-8 chunk bytes to minimize main-thread work and copying.
 - **Minimal dependencies** — only `chalk` in production.
 
@@ -76,7 +76,7 @@ Examples of deliberate choices:
 
 - `bench-chunk-sizes.ts` — chunk size × worker count sweep
 - `profile-bottlenecks-node.ts` — staged pipeline profile
-- `line-reader-readline.ts` — readline vs `readLinesFast`
+- `line-reader-readline.ts` — readline events vs `for await` vs `readLines` / `readPgnChunks`
 - `bench-worker-overhead.ts` — worker pool startup cost
 
 **Perf bench env vars:**

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A JavaScript library for batch analyzing chess games.
 - Filter games (e.g. only analyze games where WhiteElo > 1800)
 - Fully modular, track only the stats you need to preserve performance
 - Generate heatmaps out of the generated data
-- It's fast and highly parallelized: Processes ~16M moves/s on an Apple M1, >4.900.000 moves/s on a Ryzen 5 2600X (PGN parsing only)
+- It's fast and highly parallelized: Processes ~25M moves/s on an Apple M1 (PGN parsing only; no validation)
 - Handles big files easily
 - Just one dependency (chalk)
 

--- a/bench/exploratory/line-reader-readline.ts
+++ b/bench/exploratory/line-reader-readline.ts
@@ -7,7 +7,8 @@ import EventEmitter from 'node:events';
 import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 
-import { readLinesFast } from '#pgn/line-reader';
+import { readLines } from '#pgn/line-reader';
+import { readPgnChunks } from '#pgn/pgn-chunks';
 
 import { findLargestPgn } from '../lib/pgn-fixture';
 import { getRuntimeLabel } from '../lib/report';
@@ -17,25 +18,47 @@ const pgn = findLargestPgn();
 console.log(`Line reader comparison (${getRuntimeLabel()})`);
 console.log(`PGN: ${pgn.path}\n`);
 
-console.time('readline events');
-const lineReader = createInterface({
-    input: createReadStream(pgn.path),
-    crlfDelay: Infinity,
-});
-lineReader.on('line', () => {});
-await EventEmitter.once(lineReader, 'close');
-console.timeEnd('readline events');
+console.time('readline events (empty)');
+{
+    const lineReader = createInterface({
+        input: createReadStream(pgn.path),
+        crlfDelay: Infinity,
+    });
+    lineReader.on('line', () => {});
+    await EventEmitter.once(lineReader, 'close');
+}
+console.timeEnd('readline events (empty)');
+
+console.time('readLines (count)');
+{
+    let lines = 0;
+    await readLines(pgn.path, () => {
+        lines += 1;
+    });
+    void lines;
+}
+console.timeEnd('readLines (count)');
 
 console.time('readline for-await');
-const lineReader2 = createInterface({
-    input: createReadStream(pgn.path),
-    crlfDelay: Infinity,
-});
-for await (const _line of lineReader2) {
+{
+    const lineReader = createInterface({
+        input: createReadStream(pgn.path),
+        crlfDelay: Infinity,
+    });
+    for await (const _line of lineReader) {
+    }
 }
 console.timeEnd('readline for-await');
 
-console.time('readLinesFast');
-for await (const _line of readLinesFast(pgn.path)) {
+console.time('readPgnChunks (await at chunk)');
+{
+    let chunks = 0;
+    let lines = 0;
+    for await (const chunk of readPgnChunks(pgn.path)) {
+        chunks += 1;
+        lines += chunk.lineCount;
+    }
+    void chunks;
+    void lines;
 }
-console.timeEnd('readLinesFast');
+console.timeEnd('readPgnChunks (await at chunk)');

--- a/bench/exploratory/profile-bottlenecks-node.ts
+++ b/bench/exploratory/profile-bottlenecks-node.ts
@@ -8,7 +8,7 @@ import { availableParallelism } from 'node:os';
 import { performance } from 'node:perf_hooks';
 
 import { analyzePGN } from '#core/analyze';
-import { readLinesFast } from '#pgn/line-reader';
+import { readLines } from '#pgn/line-reader';
 import GameTracker from '#tracker/game-tracker';
 import PieceTracker from '#tracker/piece-tracker';
 import TileTracker from '#tracker/tile/tile-tracker';
@@ -36,7 +36,9 @@ async function stageRawBytes() {
 async function stageLineReader() {
     const t0 = performance.now();
     let lines = 0;
-    for await (const _ of readLinesFast(pgn.path)) lines += 1;
+    await readLines(pgn.path, () => {
+        lines += 1;
+    });
     return { ms: performance.now() - t0, lines };
 }
 
@@ -46,15 +48,15 @@ async function stageTokenize(readHeader: boolean) {
     let moves = 0;
     let game: { moves: string[]; [key: string]: unknown } = { moves: [] };
 
-    for await (const line of readLinesFast(pgn.path)) {
-        if (!line) continue;
-        if (line === '') continue;
+    await readLines(pgn.path, (line) => {
+        if (!line) return;
+        if (line === '') return;
         if (line.startsWith('[')) {
             if (readHeader) {
                 const m = HEADER_REGEX.exec(line);
                 if (m) game[m[1]!] = m[2];
             }
-            continue;
+            return;
         }
         const cleaned = line.replaceAll(COMMENT_REGEX, '');
         const matched = cleaned.match(MOVE_REGEX) ?? [];
@@ -64,7 +66,7 @@ async function stageTokenize(readHeader: boolean) {
             moves += game.moves.length;
             game = { moves: [] };
         }
-    }
+    });
     return { ms: performance.now() - t0, games, moves };
 }
 

--- a/bench/exploratory/profile-worker-overhead.ts
+++ b/bench/exploratory/profile-worker-overhead.ts
@@ -11,7 +11,7 @@ import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
 import { Worker } from 'node:worker_threads';
 
-import { readLinesFast } from '#pgn/line-reader';
+import { readLines } from '#pgn/line-reader';
 
 import { findLargestPgn } from '../lib/pgn-fixture';
 import { formatSeconds } from '../lib/timing';
@@ -24,16 +24,16 @@ const N_BATCHES = 20;
 
 const batches: { moves: string[] }[] = [];
 let game: { moves: string[] } = { moves: [] };
-for await (const line of readLinesFast(pgn.path)) {
-    if (!line || !line.length || line.charCodeAt(0) === 91) continue;
+await readLines(pgn.path, (line) => {
+    if (!line || !line.length || line.charCodeAt(0) === 91) return;
     const m = line.match(MOVE_REGEX);
     if (m) for (let i = 0; i < m.length; i += 1) game.moves.push(m[i]!);
     if (RESULT_REGEX.test(line)) {
         batches.push(game);
         game = { moves: [] };
-        if (batches.length >= BATCH * N_BATCHES) break;
+        if (batches.length >= BATCH * N_BATCHES) return false;
     }
-}
+});
 
 const batchGroups: { moves: string[] }[][] = [];
 for (let i = 0; i < batches.length; i += BATCH) {

--- a/bun.lock
+++ b/bun.lock
@@ -9,11 +9,11 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "bun-plugin-dts": "^0.4.0",
         "knip": "^6.29.0",
-        "oxfmt": "^0.60.0",
-        "oxlint": "^1.75.0",
+        "oxfmt": "^0.61.0",
+        "oxlint": "^1.76.0",
         "oxlint-tsgolint": "^7.0.2001",
         "tinybench": "^6.1.2",
         "tsx": "^4.23.1",
@@ -22,7 +22,7 @@
     },
   },
   "overrides": {
-    "@types/node": "^26.1.1",
+    "@types/node": "^26.1.2",
   },
   "packages": {
     "@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
@@ -165,43 +165,43 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw=="],
 
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.60.0", "", { "os": "android", "cpu": "arm" }, "sha512-1q4q4Jc8FlOMVojEisyFAVyl8h1yawNv6phjgmhGVEDeyeOdsSnSr9x0+D4mOnEKvpO5L4mxKZ/DP9X6U3A/Mw=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.61.0", "", { "os": "android", "cpu": "arm" }, "sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.60.0", "", { "os": "android", "cpu": "arm64" }, "sha512-tD41I6nCt9k8SQXft0CSjjU9jg6SwG7uMu7PxodSEHXl+GDW0868oy6tTtoJkyUze8YKFgTpz/k5LuPUnFiGLw=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.61.0", "", { "os": "android", "cpu": "arm64" }, "sha512-of8atAV0M1egGcVOMbgZCvc10sFOP3ayQBNQV5h5G3fNq8gACdEswfFk9bzGrdbM23rtg0Coxi7np7oPLcueNw=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.60.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TTpzPug96Zxdyb46KvTyIUQDdsqbumXh2TKG9C23PCT0kF7JkW56Z/quPuG9rqOFKQIi1gpRNZ7DX18LwxXPnw=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.61.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7l8+5ov4BGwtAcmpzvEik/TG3bciwyw/S3e6j5GKH7pcQqcgCVxD3AuJeP6upto+SOTBKQ4wrrdbMt0gq8fHSQ=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.60.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-CnOoWgQ7L+JL/YQaRJ+NyATciSfcftncm7y3kqyte1cGtFEGnStaCd1TAyrinkfQ7nRBfHrTs1/vTwUJr3WF2Q=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.61.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Fnz4dDDXBb7udk+DmwelNjxbD6yptyxwCqwCH2ebo4RVLxVsRfFsn/AHJC49KIltPrVokamGv4SSOsiV50DTxQ=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.60.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ychJo7S3hZxdO6eDZ9zM6F2lM9fpJS3EKS5CAUSWyprdLYxTu4gbaUKV/VBPTcMJwQa2Bpo+643y3OJ537pihA=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.61.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-mddOebKNCP+AucmzfNsk3jgbr681qAUvgMqi865GW5gWLJ/AnzXbvjQRrny0e++NAN8aphav/aRSrfFxNsNjpA=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-36IH5o55T2Fx7E0feDttt+mifxN6yk9pWv4KfhAIsP0dFnUq27331OwbpOsZdoXF9soOLWm7mQUz5+UUmyec4g=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.61.0", "", { "os": "linux", "cpu": "arm" }, "sha512-svx59iYL+DbaZGZUIoice4W0CjRXGExnbz7Re+awIb60rVxBS2KrU7Hnlx+nZYanLGLpjneUEgo/VFEKkSZAyQ=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.60.0", "", { "os": "linux", "cpu": "arm" }, "sha512-G1Ve7lAa6sFBolVI2LWHfEAqy0YKh4vnioH8uYO9kAEdgM7mR40IksIx9/Zk4+vbYew/sGa4J9Q4tZ3n9gXDHA=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.61.0", "", { "os": "linux", "cpu": "arm" }, "sha512-BYK9MPJPCf6d+fLKMTruThmEyCtHzQ1zLcsrTlUVkmnoXIaHAbfpeLYQwX1tkjs7W11dyzoi6HFvKcdnvX1zNg=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-LTQdRBf6uzj/h7Xk6lKzbGD2hrF/fK4YI9LIN1c0509tPUn8wRa3mCmrFQpEWJPLYGFrLFFMTYW1Ljj6VqW2Hw=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.61.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-QUaCNLq2/EC6G5ljOuFanl9Lgw6ZWp4co7rs4+KOMUzbGfA4Lq58FHRjjF9sVIG+93XSbo343MxFATrOU1qctA=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.60.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-2JMo3XPxMPx3hiqddSZYyaH+fKJm6cz0u8n1naYjP/CdOQOZW34i8lKBUfmbWiuFvd6KoYXLmhAyBuvojsYS7Q=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.61.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.60.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-L3C+nBD13lr306tr/PjM3RMll+BVqgFrIgUyoeHuai5oueJrRLgO3j+GO5/Cbhtkf5PSlHYTI1JY7iqBd1qa6A=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.61.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-M4MsmvqlxFiPtSRGyBYQSZxchEf463AOyd+Dh4/9xDpjWBsRtDUTDMFN5EdHinjVK1/eDJQ8MLpcYjpYayaCnA=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.61.0", "", { "os": "linux", "cpu": "none" }, "sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.60.0", "", { "os": "linux", "cpu": "none" }, "sha512-OH+9UskYuxRB+GxqdGkVN8f5UpwhqG8YscNo1wl8+KJ62cd7wZdGga6iGLJIf8kibF1WBwvlfDUx3cez/VXwFg=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.61.0", "", { "os": "linux", "cpu": "none" }, "sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.60.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-y7AAFutt9wFWBFOAn6+BHaV39usZmcr3YYH2385f+NHgPNpIF9HpqKp0jgUxPaUOCyG3oaX5VhJduL1Nw164rw=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.61.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-yKZ9+CXAI+1RO5nH/4Z/9M6DAsfOzd5bw/gtWk81KB4mpalMaRRSXfouc5/tHxazDmBek55HNPepNYBgaCew0Q=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.61.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.60.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bCUGaF6hJOYnQzLJdHLZbvGsOd5oSvGAyJhPAKum2uyLYUuXmP8vqg690DWi2hqcnIoYpqSqCrjzE5aiUAgwQg=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.61.0", "", { "os": "linux", "cpu": "x64" }, "sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.60.0", "", { "os": "none", "cpu": "arm64" }, "sha512-GrUeZOvzP30ExxfCuQiyofuUGI+OmvAgFwOO5w5p9mGPlxcyuqI+6Sy9fAKFFfLQrqKYWFgc5sYA2Unj/29nPg=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.61.0", "", { "os": "none", "cpu": "arm64" }, "sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.60.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-WD4Q954kUl2TDJV/6q7UnE2rlKk047kXLJsr4bJ2mXRaAqNXcmV3nwKUsGCc3mz/jYDBnXtJEaBErJEybK8iQQ=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.61.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-VzsAISkFxmNhJ5LBDEL9VuH6tJsVJMtqYit2LyIUf/HLnsCe4Pg9SMOjjVQzGWt0bnpyfJ94CrqTqcpNZzK+ug=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.60.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-HqDekjr8JXzVDUP1YthDZ1Y3CBEcuZT4WX3B+1kaxj8CvZA8Y2YhcEsXqoSop3tVsgjACxjnFQFDkBo0r/jq1Q=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.61.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-xv4t7yzwJoYaLB6Zv28B3W+j7brEjsyv50rLTAQgmxJzddce9fAMCxed8dSAkbWES0zz2J29nYK5FaTuD2YBHg=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-tz78yhmGPKboTMHCHSaUqXK8JrmoSejgDcWeqAtg2s07ZGKQ3rH5Jn8NuXPGNG33CDbY2e9NoQWXIVEmKO21Rw=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.61.0", "", { "os": "win32", "cpu": "x64" }, "sha512-6EZXFkqOwxdDYjIn3TSNnPk3ST5E5GiYd4FiM6UF/mCL/LZSfr6D6UygTfW3R1PCQP2quCKpCEGRlij8E3VYbg=="],
 
     "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@7.0.2001", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w=="],
 
@@ -215,49 +215,49 @@
 
     "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@7.0.2001", "", { "os": "win32", "cpu": "x64" }, "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.75.0", "", { "os": "android", "cpu": "arm" }, "sha512-lutovtFzJqlRaqpZrCqSSGaHZzl9nIxxpjLzhSRLunN6dCLylj0uzlCyQGaQDIys7rrv8kVXiFO+R4Zpn0bX7g=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.76.0", "", { "os": "android", "cpu": "arm" }, "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.75.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hXI0hDgHkw4w5nfru72aG7y+2iQJmC4waH/KV6H/hbgA6yAP5jYNx0P9yug15Hs0tWl/+mda3Jjn/2gmDT48tw=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.76.0", "", { "os": "android", "cpu": "arm64" }, "sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.75.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-D91BWbK/dMYfCcrghspPIuKs2D9LF4Z/OabVSQjw1AO6PWxArD7teDA48bm0ySFqWDaPVqmQRl5GMWNglTXyrQ=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.76.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.75.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-02mpwzf12BonZ6PT0TuQoomvEh2kVl2WGBIKWezCyToIS+rYkQZ6GXnARBAl9A4Ovm2V+Xe7M4KretyqmmcnJQ=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.76.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.75.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-qZJgLnDaBsiL5YESx2t/TZ8eXkL9fEkKoXEdzegROhlz9A0lgyGnZ0dAzJrh7LJAHQl2K9RdRueN2s/9N7+odg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.76.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.75.0", "", { "os": "linux", "cpu": "arm" }, "sha512-7XlaWA5BJD3XpCfrEqjEe6Zseeb14S7QGa304XfwKignRaKQ+eIj775BQ7nIslggWickl4IsPUFqJ+/gAyNHVg=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.76.0", "", { "os": "linux", "cpu": "arm" }, "sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.75.0", "", { "os": "linux", "cpu": "arm" }, "sha512-av6Tpv8yrcMMMOadOqENBhlsLRcGFXXwoQ0hzHhsmS9FJ4Wioy8we427GbcMe2XTxmL2e60T67H1Dyr3up+tAA=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.76.0", "", { "os": "linux", "cpu": "arm" }, "sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.75.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-WcUhd8fHT5plrA14lANevl+hOl815mVI5t2hU21oFWrZKFXIVV/Sr4rWQV0NzSvzBupbMLNc5ErEA6Ehxh5jMg=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.76.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.75.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UWzp5wRHFe/ESO3+eEaxXsTkYTGLYjnTsi/I5neEacXSItQ6WNleapfOAeA4x2b8nyhJ4uQxqvtv9pHv8kWJtQ=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.76.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.75.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-XEVRwGMLKCUKrvhLAz4F6AIh8MJrQVdSZtAmPpRZt9tGPsUnamPOcl3dS/ZQzJnar/Ymgc//+xho0L60Emzuxg=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.76.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.75.0", "", { "os": "linux", "cpu": "none" }, "sha512-mAG4DUXqfLC8cTjMD2kt3jDmVzFREYtDyeLNdLdsCcBc4Zbl2EMuiFektGBilQwkNjYnMvCqJs55U+Hyb+b+jw=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.76.0", "", { "os": "linux", "cpu": "none" }, "sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.75.0", "", { "os": "linux", "cpu": "none" }, "sha512-95hrAvriAlI+pekSomTFIn0+bawMDlDwTNVmdjsFusTHyL2JWh7TWvRNG/Lkim72uN8OiCcO9wcaC6omLP5E3w=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.76.0", "", { "os": "linux", "cpu": "none" }, "sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.75.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-4b6f2+FrtruAESrCqIKcrarzfrSx+wk2QNcp+RT91/Prc+pMQMAfyZ1rG1c3tFQNl8Bc616tx40uNXyxNBRPbQ=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.76.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.75.0", "", { "os": "linux", "cpu": "x64" }, "sha512-nshAhrUvXFUWOvqQ2soIw7HFNWvpvEV4o0cYSqPtzLiPF5gKyYTDOOTJ6Rn8g8K/iGvPIrbDA4v8+5MvnjJrrg=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.76.0", "", { "os": "linux", "cpu": "x64" }, "sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.75.0", "", { "os": "linux", "cpu": "x64" }, "sha512-e4jNxLKnxLC6sYBQRxrI2pgIIxnmMtF8U/VwNYcjTT/CLS+spH624cYVnj07bTKwaEWT37/e025isOs6j/0xqA=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.76.0", "", { "os": "linux", "cpu": "x64" }, "sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.75.0", "", { "os": "none", "cpu": "arm64" }, "sha512-hZ2lH+1qLf/DiEP9UWuQTK2JWj/BgvMB4jhIV4SmNU1wfEiYYX4TynQyAZXx0j9X4qRYizAL042SKaV+8ynh4w=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.76.0", "", { "os": "none", "cpu": "arm64" }, "sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.75.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ilj6PNzGDS3bCU0MSJH7Msh0NhH+T/mRp2shwg+q+GHeVlPwP5LEboW96aW+3kVKFk6zYZy1Xi5pZkqZh6X8KQ=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.76.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.75.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-QVit2nOEOiPhkmsrksPSkoGCdnZRNkspt8fwoYyP09te1VEbnSj4LAxua4rc8FKTmWkySVe05j8iz9GXYfF1AQ=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.76.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.75.0", "", { "os": "win32", "cpu": "x64" }, "sha512-DSxnNkBUAYARPwJtR12Ig3deWr8w0H997xP6jy33i+e0SyYJw8FKuz4+cZtpmPEhQmvlPJE3X/2vNxDmLkd/rA=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.76.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -307,9 +307,9 @@
 
     "oxc-resolver": ["oxc-resolver@11.24.2", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.24.2", "@oxc-resolver/binding-android-arm64": "11.24.2", "@oxc-resolver/binding-darwin-arm64": "11.24.2", "@oxc-resolver/binding-darwin-x64": "11.24.2", "@oxc-resolver/binding-freebsd-x64": "11.24.2", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2", "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2", "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2", "@oxc-resolver/binding-linux-arm64-musl": "11.24.2", "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2", "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2", "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2", "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2", "@oxc-resolver/binding-linux-x64-gnu": "11.24.2", "@oxc-resolver/binding-linux-x64-musl": "11.24.2", "@oxc-resolver/binding-openharmony-arm64": "11.24.2", "@oxc-resolver/binding-wasm32-wasi": "11.24.2", "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2", "@oxc-resolver/binding-win32-x64-msvc": "11.24.2" } }, "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw=="],
 
-    "oxfmt": ["oxfmt@0.60.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.60.0", "@oxfmt/binding-android-arm64": "0.60.0", "@oxfmt/binding-darwin-arm64": "0.60.0", "@oxfmt/binding-darwin-x64": "0.60.0", "@oxfmt/binding-freebsd-x64": "0.60.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.60.0", "@oxfmt/binding-linux-arm-musleabihf": "0.60.0", "@oxfmt/binding-linux-arm64-gnu": "0.60.0", "@oxfmt/binding-linux-arm64-musl": "0.60.0", "@oxfmt/binding-linux-ppc64-gnu": "0.60.0", "@oxfmt/binding-linux-riscv64-gnu": "0.60.0", "@oxfmt/binding-linux-riscv64-musl": "0.60.0", "@oxfmt/binding-linux-s390x-gnu": "0.60.0", "@oxfmt/binding-linux-x64-gnu": "0.60.0", "@oxfmt/binding-linux-x64-musl": "0.60.0", "@oxfmt/binding-openharmony-arm64": "0.60.0", "@oxfmt/binding-win32-arm64-msvc": "0.60.0", "@oxfmt/binding-win32-ia32-msvc": "0.60.0", "@oxfmt/binding-win32-x64-msvc": "0.60.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-fViX6i+gJuZWY+jI/fnR6WRbRj70GZ9RlCd30MygJrHTUNc4DxvKHWw8vBjMjffv3PgU5qWDR0AzmojQByqaZA=="],
+    "oxfmt": ["oxfmt@0.61.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.61.0", "@oxfmt/binding-android-arm64": "0.61.0", "@oxfmt/binding-darwin-arm64": "0.61.0", "@oxfmt/binding-darwin-x64": "0.61.0", "@oxfmt/binding-freebsd-x64": "0.61.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.61.0", "@oxfmt/binding-linux-arm-musleabihf": "0.61.0", "@oxfmt/binding-linux-arm64-gnu": "0.61.0", "@oxfmt/binding-linux-arm64-musl": "0.61.0", "@oxfmt/binding-linux-ppc64-gnu": "0.61.0", "@oxfmt/binding-linux-riscv64-gnu": "0.61.0", "@oxfmt/binding-linux-riscv64-musl": "0.61.0", "@oxfmt/binding-linux-s390x-gnu": "0.61.0", "@oxfmt/binding-linux-x64-gnu": "0.61.0", "@oxfmt/binding-linux-x64-musl": "0.61.0", "@oxfmt/binding-openharmony-arm64": "0.61.0", "@oxfmt/binding-win32-arm64-msvc": "0.61.0", "@oxfmt/binding-win32-ia32-msvc": "0.61.0", "@oxfmt/binding-win32-x64-msvc": "0.61.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ=="],
 
-    "oxlint": ["oxlint@1.75.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.75.0", "@oxlint/binding-android-arm64": "1.75.0", "@oxlint/binding-darwin-arm64": "1.75.0", "@oxlint/binding-darwin-x64": "1.75.0", "@oxlint/binding-freebsd-x64": "1.75.0", "@oxlint/binding-linux-arm-gnueabihf": "1.75.0", "@oxlint/binding-linux-arm-musleabihf": "1.75.0", "@oxlint/binding-linux-arm64-gnu": "1.75.0", "@oxlint/binding-linux-arm64-musl": "1.75.0", "@oxlint/binding-linux-ppc64-gnu": "1.75.0", "@oxlint/binding-linux-riscv64-gnu": "1.75.0", "@oxlint/binding-linux-riscv64-musl": "1.75.0", "@oxlint/binding-linux-s390x-gnu": "1.75.0", "@oxlint/binding-linux-x64-gnu": "1.75.0", "@oxlint/binding-linux-x64-musl": "1.75.0", "@oxlint/binding-openharmony-arm64": "1.75.0", "@oxlint/binding-win32-arm64-msvc": "1.75.0", "@oxlint/binding-win32-ia32-msvc": "1.75.0", "@oxlint/binding-win32-x64-msvc": "1.75.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g=="],
+    "oxlint": ["oxlint@1.76.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.76.0", "@oxlint/binding-android-arm64": "1.76.0", "@oxlint/binding-darwin-arm64": "1.76.0", "@oxlint/binding-darwin-x64": "1.76.0", "@oxlint/binding-freebsd-x64": "1.76.0", "@oxlint/binding-linux-arm-gnueabihf": "1.76.0", "@oxlint/binding-linux-arm-musleabihf": "1.76.0", "@oxlint/binding-linux-arm64-gnu": "1.76.0", "@oxlint/binding-linux-arm64-musl": "1.76.0", "@oxlint/binding-linux-ppc64-gnu": "1.76.0", "@oxlint/binding-linux-riscv64-gnu": "1.76.0", "@oxlint/binding-linux-riscv64-musl": "1.76.0", "@oxlint/binding-linux-s390x-gnu": "1.76.0", "@oxlint/binding-linux-x64-gnu": "1.76.0", "@oxlint/binding-linux-x64-musl": "1.76.0", "@oxlint/binding-openharmony-arm64": "1.76.0", "@oxlint/binding-win32-arm64-msvc": "1.76.0", "@oxlint/binding-win32-ia32-msvc": "1.76.0", "@oxlint/binding-win32-x64-msvc": "1.76.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw=="],
 
     "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 

--- a/package.json
+++ b/package.json
@@ -57,18 +57,18 @@
     },
     "devDependencies": {
         "@types/bun": "^1.3.14",
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "bun-plugin-dts": "^0.4.0",
         "knip": "^6.29.0",
-        "oxfmt": "^0.60.0",
-        "oxlint": "^1.75.0",
+        "oxfmt": "^0.61.0",
+        "oxlint": "^1.76.0",
         "oxlint-tsgolint": "^7.0.2001",
         "tinybench": "^6.1.2",
         "tsx": "^4.23.1",
         "typescript": "6.0.3"
     },
     "overrides": {
-        "@types/node": "^26.1.1"
+        "@types/node": "^26.1.2"
     },
     "engines": {
         "node": ">=22"

--- a/src/core/game-processor.ts
+++ b/src/core/game-processor.ts
@@ -6,7 +6,7 @@ import { normalizeAnalysisConfigs } from '#core/analysis-config';
 import { createWorkerResultHandler, finishTrackers } from '#core/tracker-merge';
 import WorkerPool from '#core/worker-pool';
 import { GameAssembler } from '#pgn/game-assembler';
-import { readLinesFast } from '#pgn/line-reader';
+import { readLines } from '#pgn/line-reader';
 import { readPgnChunks } from '#pgn/pgn-chunks';
 import GameReplayer from '#replay/game-replayer';
 import { resolveReplayPolicy } from '#replay/replay-policy';
@@ -160,9 +160,9 @@ class GameProcessor {
         const gameReplayer = new GameReplayer();
         const gameAssembler = new GameAssembler({ readInHeader: this.readInHeader });
 
-        lineLoop: for await (const line of readLinesFast(path)) {
+        await readLines(path, (line) => {
             const game = gameAssembler.processLine(line);
-            if (!game) continue;
+            if (!game) return;
 
             for (const cfg of this.configs) {
                 if (!cfg.isDone && (!cfg.config.hasFilter || cfg.config.filter(game))) {
@@ -176,11 +176,11 @@ class GameProcessor {
                     );
                     if (cfg.readGames === cfg.config.maxGames) {
                         cfg.isDone = true;
-                        if (this.configs.every((c) => c.isDone)) break lineLoop;
+                        if (this.configs.every((c) => c.isDone)) return false;
                     }
                 }
             }
-        }
+        });
 
         return finishTrackers(this.configs);
     }

--- a/src/pgn/__tests__/line-reader.test.ts
+++ b/src/pgn/__tests__/line-reader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { readLinesFast } from '#pgn/line-reader';
+import { readLines } from '#pgn/line-reader';
 
 const FIXTURES_DIR = join(new URL('../../../test/fixtures', import.meta.url).pathname);
 const CRLF_FIXTURE = join(FIXTURES_DIR, 'crlf-endings.pgn');
@@ -17,13 +17,13 @@ async function writeTmpPgn(name: string, content: string): Promise<string> {
 
 async function collectLines(path: string): Promise<string[]> {
     const lines: string[] = [];
-    for await (const line of readLinesFast(path)) {
+    await readLines(path, (line) => {
         lines.push(line);
-    }
+    });
     return lines;
 }
 
-describe('readLinesFast', () => {
+describe('readLines', () => {
     it('reassembles a line split across read chunks', async () => {
         const longLine = 'x'.repeat(70 * 1024);
         const path = await writeTmpPgn('long-line.pgn', longLine);
@@ -33,12 +33,12 @@ describe('readLinesFast', () => {
         expect(lines).toEqual([longLine]);
     });
 
-    it('preserves empty lines and trailing newline', async () => {
+    it('preserves empty lines (readline omits a phantom line after the final newline)', async () => {
         const path = await writeTmpPgn('empty-lines.pgn', 'a\n\nb\n');
 
         const lines = await collectLines(path);
 
-        expect(lines).toEqual(['a', '', 'b', '']);
+        expect(lines).toEqual(['a', '', 'b']);
     });
 
     it('strips CRLF line endings', async () => {
@@ -60,7 +60,18 @@ describe('readLinesFast', () => {
             '',
             '1. e4 1... e5 ',
             '2. Nf3 1-0',
-            '',
         ]);
+    });
+
+    it('stops early when the handler returns false', async () => {
+        const path = await writeTmpPgn('early-stop.pgn', 'a\nb\nc\nd\n');
+        const lines: string[] = [];
+
+        await readLines(path, (line) => {
+            lines.push(line);
+            if (line === 'b') return false;
+        });
+
+        expect(lines).toEqual(['a', 'b']);
     });
 });

--- a/src/pgn/__tests__/line-reader.test.ts
+++ b/src/pgn/__tests__/line-reader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { readLines } from '#pgn/line-reader';
+import { openLineStream, readLines } from '#pgn/line-reader';
 
 const FIXTURES_DIR = join(new URL('../../../test/fixtures', import.meta.url).pathname);
 const CRLF_FIXTURE = join(FIXTURES_DIR, 'crlf-endings.pgn');
@@ -73,5 +73,34 @@ describe('readLines', () => {
         });
 
         expect(lines).toEqual(['a', 'b']);
+    });
+});
+
+describe('openLineStream', () => {
+    it('supports pause and resume without dropping lines', async () => {
+        const path = await writeTmpPgn('pause-resume.pgn', 'a\nb\nc\nd\n');
+        const seen: string[] = [];
+
+        await new Promise<void>((resolve, reject) => {
+            let pausedAfterB = false;
+            const stream = openLineStream(path, {
+                onLine: (line) => {
+                    seen.push(line);
+                    if (line === 'b' && !pausedAfterB) {
+                        pausedAfterB = true;
+                        stream.pause();
+                        queueMicrotask(() => {
+                            stream.resume();
+                        });
+                    }
+                },
+                onClose: () => {
+                    resolve();
+                },
+                onError: reject,
+            });
+        });
+
+        expect(seen).toEqual(['a', 'b', 'c', 'd']);
     });
 });

--- a/src/pgn/__tests__/pgn-chunk.test.ts
+++ b/src/pgn/__tests__/pgn-chunk.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'bun:test';
 
 import { parseGamesFromLines } from '#pgn/game-assembler';
-import { readLinesFast } from '#pgn/line-reader';
+import { readLines } from '#pgn/line-reader';
 import { chunkEndsWithCompleteGame, readPgnChunks, type PgnChunkConfig } from '#pgn/pgn-chunks';
 
 import { fixturePath, repeatPgn, cleanupTmpPgns } from '../../../test/helpers/fixtures';
@@ -30,8 +30,8 @@ describe('readPgnChunks', () => {
         const path = fixturePath('comments-singleline');
         const lineGames: { moves: string[] }[] = [];
         let game: { moves: string[] } = { moves: [] };
-        for await (const line of readLinesFast(path)) {
-            if (!line.length || line.startsWith('[')) continue;
+        await readLines(path, (line) => {
+            if (!line.length || line.startsWith('[')) return;
             const cleaned = line.replace(/\{.*?\}|\(.*?\)/g, '');
             const matched = cleaned.match(/[RNBQKOa-h][^\s?!#+]+/g) ?? [];
             game.moves.push(...matched);
@@ -39,7 +39,7 @@ describe('readPgnChunks', () => {
                 lineGames.push(game);
                 game = { moves: [] };
             }
-        }
+        });
 
         const chunkGames = [];
         for await (const chunk of readPgnChunks(path, { targetBytes: 1 })) {

--- a/src/pgn/line-reader.ts
+++ b/src/pgn/line-reader.ts
@@ -1,5 +1,5 @@
-import { createReadStream } from 'node:fs';
-import { createInterface } from 'node:readline';
+import { createReadStream, type ReadStream } from 'node:fs';
+import { createInterface, type Interface } from 'node:readline';
 
 /**
  * Sync line handler. Return `false` to stop reading early (closes the stream).
@@ -7,47 +7,114 @@ import { createInterface } from 'node:readline';
  */
 export type LineHandler = (line: string) => void | false;
 
+/** Handlers for {@link openLineStream}. Attach at open time so no lines are missed. */
+export interface LineStreamHandlers {
+    onLine: (line: string) => void;
+    onClose?: () => void;
+    onError?: (err: Error) => void;
+}
+
+/**
+ * Controllable UTF-8 line stream over a file.
+ * Sole owner of `fs` / `readline` I/O in the PGN pipeline.
+ */
+export interface LineStream {
+    /** Pause the underlying read stream (backpressure). No-op if already closed. */
+    pause(): void;
+    /** Resume after {@link pause}. No-op if already closed. */
+    resume(): void;
+    /** Close the readline interface and destroy the file stream. */
+    close(): void;
+    readonly closed: boolean;
+}
+
+/**
+ * Open a file for line-oriented reading via readline `'line'` events.
+ *
+ * **Performance:** Event-mode is intentional. Sync `'line'` handlers beat
+ * `for await` / async-iterator pull by a wide margin on large PGNs (see
+ * `bench/exploratory/line-reader-readline.ts` and Node's readline docs). Do not
+ * wrap this in per-line `await` — that reintroduces the slow path. Keep handler
+ * work synchronous; use {@link LineStream.pause} / {@link LineStream.resume} for
+ * chunk-level backpressure instead.
+ *
+ * Callers that need backpressure (e.g. chunking) should use pause/resume.
+ * Prefer {@link readLines} for simple full-file scans.
+ */
+export function openLineStream(file: string, handlers: LineStreamHandlers): LineStream {
+    const input: ReadStream = createReadStream(file, { encoding: 'utf8' });
+    const rl: Interface = createInterface({ input, crlfDelay: Infinity });
+
+    let closed = false;
+
+    const stream: LineStream = {
+        get closed() {
+            return closed;
+        },
+        pause() {
+            if (!closed) rl.pause();
+        },
+        resume() {
+            if (!closed) rl.resume();
+        },
+        close() {
+            if (closed) return;
+            closed = true;
+            rl.close();
+            input.destroy();
+        },
+    };
+
+    rl.on('line', (line) => {
+        if (closed) return;
+        handlers.onLine(line);
+    });
+
+    rl.once('close', () => {
+        closed = true;
+        handlers.onClose?.();
+    });
+
+    const fail = (err: Error) => {
+        if (closed) return;
+        handlers.onError?.(err);
+        stream.close();
+    };
+
+    rl.once('error', fail);
+    input.once('error', fail);
+
+    return stream;
+}
+
 /**
  * Read a file line-by-line via readline `'line'` events.
  *
- * Processing stays on the sync event path; the returned promise resolves when
- * the stream closes (EOF, early stop, or error).
+ * Processing stays on the sync event path (see {@link openLineStream} for why);
+ * the returned promise resolves when the stream closes (EOF, early stop, or error).
  */
 export async function readLines(file: string, onLine: LineHandler): Promise<void> {
-    const input = createReadStream(file, { encoding: 'utf8' });
-    const rl = createInterface({ input, crlfDelay: Infinity });
-
-    let stopped = false;
     let handlerError: unknown;
 
     await new Promise<void>((resolve, reject) => {
-        const fail = (err: Error) => {
-            stopped = true;
-            reject(err);
-        };
-
-        rl.on('line', (line) => {
-            if (stopped) return;
-            try {
-                if (onLine(line) === false) {
-                    stopped = true;
-                    rl.close();
+        const stream = openLineStream(file, {
+            onLine: (line) => {
+                try {
+                    if (onLine(line) === false) {
+                        stream.close();
+                    }
+                } catch (err) {
+                    handlerError = err;
+                    stream.close();
                 }
-            } catch (err) {
-                stopped = true;
-                handlerError = err;
-                rl.close();
-            }
+            },
+            onClose: () => {
+                resolve();
+            },
+            onError: (err) => {
+                reject(err);
+            },
         });
-
-        rl.once('close', () => {
-            resolve();
-        });
-        rl.once('error', fail);
-        input.once('error', fail);
-    }).finally(() => {
-        rl.close();
-        input.destroy();
     });
 
     if (handlerError !== undefined) throw handlerError;

--- a/src/pgn/line-reader.ts
+++ b/src/pgn/line-reader.ts
@@ -1,192 +1,54 @@
 import { createReadStream } from 'node:fs';
-
-const DEFAULT_QUEUE_SIZE = 1024;
-
-/* https://github.com/nodejs/node/blob/bae03c4e30f927676203f61ff5a34fe0a0c0bbc9/lib/internal/fixed_queue.js
- * The FixedQueue is implemented as a singly-linked list of fixed-size
- * circular buffers. It looks something like this:
- *
- *  head                                                       tail
- *    |                                                          |
- *    v                                                          v
- * +-----------+ <-----\       +-----------+ <------\         +-----------+
- * |  [null]   |        \----- |   next    |         \------- |   next    |
- * +-----------+               +-----------+                  +-----------+
- * |   item    | <-- bottom    |   item    | <-- bottom       |  [empty]  |
- * |   item    |               |   item    |                  |  [empty]  |
- * |   item    |               |   item    |                  |  [empty]  |
- * |   item    |               |   item    |                  |  [empty]  |
- * |   item    |               |   item    |       bottom --> |   item    |
- * |   item    |               |   item    |                  |   item    |
- * |    ...    |               |    ...    |                  |    ...    |
- * |   item    |               |   item    |                  |   item    |
- * |   item    |               |   item    |                  |   item    |
- * |  [empty]  | <-- top       |   item    |                  |   item    |
- * |  [empty]  |               |   item    |                  |   item    |
- * |  [empty]  |               |  [empty]  | <-- top  top --> |  [empty]  |
- * +-----------+               +-----------+                  +-----------+
- *
- * Or, if there is only one circular buffer, it looks something
- * like either of these:
- *
- *  head   tail                                 head   tail
- *    |     |                                     |     |
- *    v     v                                     v     v
- * +-----------+                               +-----------+
- * |  [null]   |                               |  [null]   |
- * +-----------+                               +-----------+
- * |  [empty]  |                               |   item    |
- * |  [empty]  |                               |   item    |
- * |   item    | <-- bottom            top --> |  [empty]  |
- * |   item    |                               |  [empty]  |
- * |  [empty]  | <-- top            bottom --> |   item    |
- * |  [empty]  |                               |   item    |
- * +-----------+                               +-----------+
- *
- * Adding a value means moving `top` forward by one, removing means
- * moving `bottom` forward by one. After reaching the end, the queue
- * wraps around.
- *
- * When `top === bottom` the current queue is empty and when
- * `top + 1 === bottom` it's full. This wastes a single space of storage
- * but allows much quicker checks.
- */
-
-class FixedCircularBuffer<T> {
-    kMask: number;
-    top: number;
-    bottom: number;
-    list: (T | undefined)[];
-    next: FixedCircularBuffer<T> | null;
-
-    constructor(kSize: number) {
-        this.bottom = 0;
-        this.top = 0;
-        this.list = new Array(kSize);
-        this.next = null;
-        this.kMask = kSize - 1;
-    }
-
-    isEmpty() {
-        return this.top === this.bottom;
-    }
-
-    isFull() {
-        return ((this.top + 1) & this.kMask) === this.bottom;
-    }
-
-    push(data: T) {
-        this.list[this.top] = data;
-        this.top = (this.top + 1) & this.kMask;
-    }
-
-    shift() {
-        const { list, bottom } = this;
-        const nextItem = list[bottom];
-        if (nextItem === undefined) return null;
-        list[bottom] = undefined;
-        this.bottom = (bottom + 1) & this.kMask;
-        return nextItem;
-    }
-}
-
-class FixedQueue<T> {
-    head: FixedCircularBuffer<T>;
-    tail: FixedCircularBuffer<T>;
-
-    constructor(private readonly kSize = DEFAULT_QUEUE_SIZE) {
-        this.head = this.tail = new FixedCircularBuffer(kSize);
-    }
-
-    isEmpty() {
-        return this.head.isEmpty();
-    }
-
-    push(...data: T[]) {
-        for (const item of data) {
-            if (this.head.isFull()) {
-                // Head is full: Creates a new queue, sets the old queue's `.next` to it,
-                // and sets it as the new main queue.
-                this.head = this.head.next = new FixedCircularBuffer(this.kSize);
-            }
-            this.head.push(item);
-        }
-    }
-
-    shift() {
-        const tail = this.tail;
-        const next = tail.shift();
-        if (tail.isEmpty() && tail.next !== null) {
-            // If there is another queue, it forms the new tail.
-            this.tail = tail.next;
-            tail.next = null;
-        }
-        return next;
-    }
-}
-
-/** Strip a trailing CR from CRLF (or rare CR-only) line endings. */
-function stripCarriageReturn(line: string): string {
-    const last = line.charCodeAt(line.length - 1);
-    return last === 13 ? line.slice(0, -1) : line;
-}
+import { createInterface } from 'node:readline';
 
 /**
- * Custom line reader that reads lines faster than the native readline module.
- * @param file - The file to read.
- * @returns An async iterator that yields lines from the file.
- * @see https://github.com/oven-sh/bun/issues/5136#issuecomment-3503523219
+ * Sync line handler. Return `false` to stop reading early (closes the stream).
+ * Keep work synchronous — awaiting here would reintroduce per-line async overhead.
  */
-export function readLinesFast(file: string): AsyncIterable<string> {
-    const rs = createReadStream(file, { encoding: 'utf-8' });
-    const sourceIterator: AsyncIterator<string> = rs.iterator();
+export type LineHandler = (line: string) => void | false;
 
-    const cache: FixedQueue<string> = new FixedQueue();
-    let leftover = '';
+/**
+ * Read a file line-by-line via readline `'line'` events.
+ *
+ * Processing stays on the sync event path; the returned promise resolves when
+ * the stream closes (EOF, early stop, or error).
+ */
+export async function readLines(file: string, onLine: LineHandler): Promise<void> {
+    const input = createReadStream(file, { encoding: 'utf8' });
+    const rl = createInterface({ input, crlfDelay: Infinity });
 
-    /** Returns the next line from the file. */
-    const next = async (): Promise<IteratorResult<string>> => {
-        // Try to get a line from the cache.
-        let line: string | null = cache.shift();
+    let stopped = false;
+    let handlerError: unknown;
 
-        // If the cache is empty, read the next chunk from the stream.
-        while (line === null) {
-            // oxlint-disable-next-line no-await-in-loop
-            const result = await sourceIterator.next();
+    await new Promise<void>((resolve, reject) => {
+        const fail = (err: Error) => {
+            stopped = true;
+            reject(err);
+        };
 
-            // If the file was fully read, return the leftover line.
-            if (result.done) {
-                if (leftover !== '') {
-                    line = stripCarriageReturn(leftover);
-                    leftover = '';
+        rl.on('line', (line) => {
+            if (stopped) return;
+            try {
+                if (onLine(line) === false) {
+                    stopped = true;
+                    rl.close();
                 }
-                break;
+            } catch (err) {
+                stopped = true;
+                handlerError = err;
+                rl.close();
             }
+        });
 
-            // Combine the leftover line from the previous chunk with the new chunk.
-            const combined = leftover + result.value;
-            leftover = '';
+        rl.once('close', () => {
+            resolve();
+        });
+        rl.once('error', fail);
+        input.once('error', fail);
+    }).finally(() => {
+        rl.close();
+        input.destroy();
+    });
 
-            // Split the combined line into parts.
-            const parts = combined.split('\n');
-
-            // If the line does not end with a newline, save the last part as the leftover.
-            const endsWithNewline = result.value.charCodeAt(result.value.length - 1) === 10;
-            if (!endsWithNewline) leftover = parts.pop() ?? '';
-
-            // Add the parts to the cache.
-            cache.push(...parts.map(stripCarriageReturn));
-
-            // Try to get a line from the cache again.
-            line = cache.shift();
-        }
-
-        if (line !== null) return { value: line, done: false };
-
-        return { done: true, value: undefined };
-    };
-
-    return {
-        [Symbol.asyncIterator]: () => ({ next }),
-    };
+    if (handlerError !== undefined) throw handlerError;
 }

--- a/src/pgn/pgn-chunks.ts
+++ b/src/pgn/pgn-chunks.ts
@@ -1,4 +1,6 @@
-import { readLinesFast } from '#pgn/line-reader';
+import { createReadStream } from 'node:fs';
+import { createInterface, type Interface } from 'node:readline';
+
 import { isGameResultLine, stripComments } from '#pgn/movetext-tokenizer';
 
 /** Default chunk size (~4 MB) for worker-side PGN dispatch. */
@@ -72,57 +74,47 @@ export function chunkEndsWithCompleteGame(lines: string[]): boolean {
     return true;
 }
 
+type ChunkResult = IteratorResult<PgnChunk>;
+
 /**
  * Stream a PGN file as raw text chunks aligned to complete games.
  * The main thread only splits lines and checks result boundaries — no move tokenization.
+ *
+ * Lines are consumed via readline `'line'` events (sync hot path). `await` only happens
+ * between chunks via the returned async iterator.
  */
-export function readPgnChunks(file: string, config: PgnChunkConfig = {}) {
+export function readPgnChunks(file: string, config: PgnChunkConfig = {}): AsyncIterable<PgnChunk> {
     const targetBytes = config.targetBytes ?? DEFAULT_PGN_CHUNK_BYTES;
     const maxLines = config.maxLines ?? 50_000;
     const minLines = config.minLines ?? 0;
 
-    const iter = readLinesFast(file)[Symbol.asyncIterator]();
+    const input = createReadStream(file, { encoding: 'utf8' });
+    const rl: Interface = createInterface({ input, crlfDelay: Infinity });
+
     const accumulator: string[] = [];
     let byteSize = 0;
-    let inputDone = false;
+    /** True once the current fill has reached the byte/line target and is waiting on a game boundary. */
+    let extendingToBoundary = false;
 
-    const readLine = async (): Promise<string | null> => {
-        if (inputDone) return null;
-        const result = await iter.next();
-        if (result.done) {
-            inputDone = true;
-            return null;
-        }
-        return result.value;
-    };
+    const pending: ChunkResult[] = [];
+    let waiter: ((result: ChunkResult) => void) | null = null;
+    let closed = false;
+    let streamError: Error | null = null;
 
     const pushLine = (line: string) => {
         accumulator.push(line);
         byteSize += line.length + 1;
     };
 
-    const next = async (): Promise<IteratorResult<PgnChunk>> => {
-        let line = await readLine();
-        while (line !== null) {
-            pushLine(line);
-            const hitByteTarget = byteSize >= targetBytes && accumulator.length >= minLines;
-            const hitLineCap = accumulator.length >= maxLines;
-            if (hitByteTarget || hitLineCap) break;
-            // oxlint-disable-next-line no-await-in-loop
-            line = await readLine();
-        }
+    const hitAccumulationTarget = (): boolean => {
+        const hitByteTarget = byteSize >= targetBytes && accumulator.length >= minLines;
+        const hitLineCap = accumulator.length >= maxLines;
+        return hitByteTarget || hitLineCap;
+    };
 
-        if (accumulator.length === 0) return { done: true, value: undefined };
-
-        while (findLastCompleteGameLineIndex(accumulator) === -1) {
-            // oxlint-disable-next-line no-await-in-loop
-            const nextLine = await readLine();
-            if (nextLine === null) break;
-            pushLine(nextLine);
-        }
-
+    const takeCompleteChunk = (): PgnChunk | null => {
         const lastResultIdx = findLastCompleteGameLineIndex(accumulator);
-        if (lastResultIdx === -1) return { done: true, value: undefined };
+        if (lastResultIdx === -1) return null;
 
         const completeLines = accumulator.slice(0, lastResultIdx + 1);
         const remainder = accumulator.slice(lastResultIdx + 1);
@@ -137,16 +129,113 @@ export function readPgnChunks(file: string, config: PgnChunkConfig = {}) {
         }
 
         return {
-            value: {
-                text,
-                bytes: encodePgnChunkText(text),
-                lineCount: completeLines.length,
-            },
-            done: false,
+            text,
+            bytes: encodePgnChunkText(text),
+            lineCount: completeLines.length,
         };
     };
 
+    const deliver = (result: ChunkResult) => {
+        if (waiter) {
+            const resolve = waiter;
+            waiter = null;
+            resolve(result);
+            return;
+        }
+        pending.push(result);
+    };
+
+    const tryEmitChunk = (): boolean => {
+        const chunk = takeCompleteChunk();
+        if (!chunk) return false;
+        extendingToBoundary = false;
+        // Pause for backpressure while the consumer awaits the next chunk.
+        // Skip when already closed (final flush uses deliver directly).
+        if (!closed) rl.pause();
+        deliver({ value: chunk, done: false });
+        return true;
+    };
+
+    const fail = (err: Error) => {
+        if (streamError) return;
+        streamError = err;
+        closed = true;
+        if (waiter) {
+            const rejectWaiter = waiter;
+            waiter = null;
+            // Prefer reject via next()'s streamError check.
+            rejectWaiter({ value: undefined, done: true });
+        }
+        rl.close();
+        input.destroy();
+    };
+
+    rl.on('line', (line) => {
+        if (closed) return;
+        pushLine(line);
+
+        if (!extendingToBoundary) {
+            if (!hitAccumulationTarget()) return;
+            extendingToBoundary = true;
+        }
+
+        tryEmitChunk();
+    });
+
+    rl.on('close', () => {
+        closed = true;
+        // Final flush without pause — the interface is already closed.
+        if (accumulator.length > 0) {
+            const chunk = takeCompleteChunk();
+            if (chunk) deliver({ value: chunk, done: false });
+        }
+        deliver({ value: undefined, done: true });
+    });
+
+    rl.on('error', (err) => {
+        fail(err);
+    });
+
+    input.on('error', (err) => {
+        fail(err);
+    });
+
+    const next = (): Promise<ChunkResult> => {
+        if (streamError) return Promise.reject(streamError);
+
+        const queued = pending.shift();
+        if (queued !== undefined) {
+            if (!queued.done && !closed) rl.resume();
+            return Promise.resolve(queued);
+        }
+
+        if (closed) {
+            return Promise.resolve({ value: undefined, done: true });
+        }
+
+        return new Promise<ChunkResult>((resolve, reject) => {
+            waiter = (result) => {
+                if (streamError) {
+                    reject(streamError);
+                    return;
+                }
+                resolve(result);
+            };
+            rl.resume();
+        });
+    };
+
     return {
-        [Symbol.asyncIterator]: () => ({ next }),
+        [Symbol.asyncIterator]: () => ({
+            next,
+            async return(): Promise<ChunkResult> {
+                closed = true;
+                rl.close();
+                input.destroy();
+                waiter = null;
+                pending.length = 0;
+                return { value: undefined, done: true };
+            },
+        }),
     };
 }

--- a/src/pgn/pgn-chunks.ts
+++ b/src/pgn/pgn-chunks.ts
@@ -1,6 +1,4 @@
-import { createReadStream } from 'node:fs';
-import { createInterface, type Interface } from 'node:readline';
-
+import { openLineStream, type LineStream } from '#pgn/line-reader';
 import { isGameResultLine, stripComments } from '#pgn/movetext-tokenizer';
 
 /** Default chunk size (~4 MB) for worker-side PGN dispatch. */
@@ -78,18 +76,15 @@ type ChunkResult = IteratorResult<PgnChunk>;
 
 /**
  * Stream a PGN file as raw text chunks aligned to complete games.
- * The main thread only splits lines and checks result boundaries — no move tokenization.
  *
- * Lines are consumed via readline `'line'` events (sync hot path). `await` only happens
- * between chunks via the returned async iterator.
+ * I/O lives in {@link openLineStream}; this module only accumulates lines, cuts on
+ * game boundaries, and encodes transferable bytes. `await` happens between chunks
+ * (not per line) via the returned async iterator.
  */
 export function readPgnChunks(file: string, config: PgnChunkConfig = {}): AsyncIterable<PgnChunk> {
     const targetBytes = config.targetBytes ?? DEFAULT_PGN_CHUNK_BYTES;
     const maxLines = config.maxLines ?? 50_000;
     const minLines = config.minLines ?? 0;
-
-    const input = createReadStream(file, { encoding: 'utf8' });
-    const rl: Interface = createInterface({ input, crlfDelay: Infinity });
 
     const accumulator: string[] = [];
     let byteSize = 0;
@@ -98,8 +93,9 @@ export function readPgnChunks(file: string, config: PgnChunkConfig = {}): AsyncI
 
     const pending: ChunkResult[] = [];
     let waiter: ((result: ChunkResult) => void) | null = null;
-    let closed = false;
+    let finished = false;
     let streamError: Error | null = null;
+    let lines: LineStream;
 
     const pushLine = (line: string) => {
         accumulator.push(line);
@@ -150,54 +146,42 @@ export function readPgnChunks(file: string, config: PgnChunkConfig = {}): AsyncI
         if (!chunk) return false;
         extendingToBoundary = false;
         // Pause for backpressure while the consumer awaits the next chunk.
-        // Skip when already closed (final flush uses deliver directly).
-        if (!closed) rl.pause();
+        lines.pause();
         deliver({ value: chunk, done: false });
         return true;
     };
 
-    const fail = (err: Error) => {
-        if (streamError) return;
-        streamError = err;
-        closed = true;
-        if (waiter) {
-            const rejectWaiter = waiter;
-            waiter = null;
-            // Prefer reject via next()'s streamError check.
-            rejectWaiter({ value: undefined, done: true });
-        }
-        rl.close();
-        input.destroy();
-    };
+    lines = openLineStream(file, {
+        onLine: (line) => {
+            pushLine(line);
 
-    rl.on('line', (line) => {
-        if (closed) return;
-        pushLine(line);
+            if (!extendingToBoundary) {
+                if (!hitAccumulationTarget()) return;
+                extendingToBoundary = true;
+            }
 
-        if (!extendingToBoundary) {
-            if (!hitAccumulationTarget()) return;
-            extendingToBoundary = true;
-        }
-
-        tryEmitChunk();
-    });
-
-    rl.on('close', () => {
-        closed = true;
-        // Final flush without pause — the interface is already closed.
-        if (accumulator.length > 0) {
-            const chunk = takeCompleteChunk();
-            if (chunk) deliver({ value: chunk, done: false });
-        }
-        deliver({ value: undefined, done: true });
-    });
-
-    rl.on('error', (err) => {
-        fail(err);
-    });
-
-    input.on('error', (err) => {
-        fail(err);
+            tryEmitChunk();
+        },
+        onClose: () => {
+            finished = true;
+            // Final flush without pause — the line stream is already closed.
+            if (accumulator.length > 0) {
+                const chunk = takeCompleteChunk();
+                if (chunk) deliver({ value: chunk, done: false });
+            }
+            deliver({ value: undefined, done: true });
+        },
+        onError: (err) => {
+            if (streamError) return;
+            streamError = err;
+            finished = true;
+            if (waiter) {
+                const rejectWaiter = waiter;
+                waiter = null;
+                rejectWaiter({ value: undefined, done: true });
+            }
+            lines.close();
+        },
     });
 
     const next = (): Promise<ChunkResult> => {
@@ -205,11 +189,11 @@ export function readPgnChunks(file: string, config: PgnChunkConfig = {}): AsyncI
 
         const queued = pending.shift();
         if (queued !== undefined) {
-            if (!queued.done && !closed) rl.resume();
+            if (!queued.done && !lines.closed) lines.resume();
             return Promise.resolve(queued);
         }
 
-        if (closed) {
+        if (finished) {
             return Promise.resolve({ value: undefined, done: true });
         }
 
@@ -221,7 +205,7 @@ export function readPgnChunks(file: string, config: PgnChunkConfig = {}): AsyncI
                 }
                 resolve(result);
             };
-            rl.resume();
+            lines.resume();
         });
     };
 
@@ -229,9 +213,8 @@ export function readPgnChunks(file: string, config: PgnChunkConfig = {}): AsyncI
         [Symbol.asyncIterator]: () => ({
             next,
             async return(): Promise<ChunkResult> {
-                closed = true;
-                rl.close();
-                input.destroy();
+                finished = true;
+                lines.close();
                 waiter = null;
                 pending.length = 0;
                 return { value: undefined, done: true };


### PR DESCRIPTION
Switches from for..await to a sync event-based line reader for a big perf win (17M -> 25M moves/s; parsing only; no validation).