### PR TITLE
refactor(heatmaps): simplify `generateHeatmap` API shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Heatmaps:** `generateHeatmap` / `generateComparisonHeatmap` take an analysis function directly (e.g. `TileHeatmapPresets.TILE_OCC_ALL` or a custom `HeatmapAnalysisFunc`). The preset map is no longer a separate argument; options are only `{ square?, optData? }`.
+- **Heatmaps:** `generateHeatmap` / `generateComparisonHeatmap` take an analysis function directly (e.g. `TileHeatmapPresets.TILE_OCC_ALL` or a custom `HeatmapAnalysisFunc`). The preset map is no longer a separate argument; options are only `{ square? }`. Dropped `optData` — close over outer scope instead.
 
 ## [4.0.0-alpha.2] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Heatmaps:** `generateHeatmap` / `generateComparisonHeatmap` take an analysis function directly (e.g. `TileHeatmapPresets.TILE_OCC_ALL` or a custom `HeatmapAnalysisFunc`). The preset map is no longer a separate argument; options are only `{ square?, optData? }`.
+
 ## [4.0.0-alpha.2] - 2026-08-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import { TileTracker, generateHeatmap, TileHeatmapPresets } from 'chessalyzer/tr
 const result = await analyzePGN('<pathToPgnFile>', { trackers: [TileTracker] });
 
 const { state } = result.runs[0].trackers[0];
-const heatmap = generateHeatmap(state, TileHeatmapPresets, { analysis: 'TILE_OCC_ALL' });
+const heatmap = generateHeatmap(state, TileHeatmapPresets.TILE_OCC_ALL);
 
 printHeatmap(heatmap);
 ```

--- a/docs/content/docs/basic-usage.mdx
+++ b/docs/content/docs/basic-usage.mdx
@@ -16,7 +16,7 @@ const result = await analyzePGN('<pathToPgnFile>', { trackers: [TileTracker] });
 console.log(result.gameCount, result.moveCount, result.movesPerSecond);
 
 const { state } = result.runs[0].trackers[0];
-const heatmapData = generateHeatmap(state, TileHeatmapPresets, { analysis: 'TILE_OCC_ALL' });
+const heatmapData = generateHeatmap(state, TileHeatmapPresets.TILE_OCC_ALL);
 
 printHeatmap(heatmapData);
 ```
@@ -25,7 +25,7 @@ printHeatmap(heatmapData);
 
 1. **`analyzePGN`** read the PGN, replayed each game, and accumulated stats into plain state owned by the framework.
 2. **`result.runs[0].trackers[0].state`** holds the tile stats; `tracker` is the definition you passed in.
-3. **`generateHeatmap(state, TileHeatmapPresets, { analysis: 'TILE_OCC_ALL' })`** turned that state into a per-square value map using a built-in preset.
+3. **`generateHeatmap(state, TileHeatmapPresets.TILE_OCC_ALL)`** turned that state into a per-square value map using a built-in preset.
 4. **`printHeatmap`** rendered a quick color preview in the terminal (if your terminal supports colors).
 
 Inspect `state.tiles` directly, or generate other heatmap presets. See [Trackers](/docs/trackers) and [Heatmaps](/docs/heatmaps).

--- a/docs/content/docs/comparing-analyses.mdx
+++ b/docs/content/docs/comparing-analyses.mdx
@@ -9,7 +9,7 @@ This example compares tile occupation for high-rated vs low-rated white players 
 
 ```javascript
 import { analyzePGN } from 'chessalyzer';
-import { generateComparisonHeatmap, TileHeatmapPresets, TileTracker } from 'chessalyzer/trackers';
+import { generateComparisonHeatmap, TileTracker } from 'chessalyzer/trackers';
 import { squareToCoords } from 'chessalyzer/replay';
 
 const result = await analyzePGN('<pathToPgnFile>', {
@@ -38,9 +38,7 @@ const compareFunc = ({ data, loopSquare }) => {
     return (val * 100) / data.movesTotal;
 };
 
-const heatmapData = generateComparisonHeatmap(state1, state2, TileHeatmapPresets, {
-    analysis: compareFunc,
-});
+const heatmapData = generateComparisonHeatmap(state1, state2, compareFunc);
 ```
 
 `generateComparisonHeatmap` builds two heatmaps from the same analysis function and returns per-cell percentage differences.

--- a/docs/content/docs/heatmaps/custom-functions.mdx
+++ b/docs/content/docs/heatmaps/custom-functions.mdx
@@ -3,24 +3,22 @@ title: Custom heatmap functions
 description: Write your own per-square calculation for generateHeatmap.
 ---
 
-Pass a function via the `analysis` option to `generateHeatmap(state, presets, { analysis })`. The function is called for every square on the board.
+Pass any function as the `analysis` argument to `generateHeatmap(state, analysis, options?)`. The function is called for every square on the board.
 
 ```javascript
-import { generateHeatmap, TileHeatmapPresets } from 'chessalyzer/trackers';
+import { generateHeatmap } from 'chessalyzer/trackers';
 import { squareToCoords } from 'chessalyzer/replay';
 
 const { state } = result.runs[0].trackers[0];
 
-const heatmapData = generateHeatmap(state, TileHeatmapPresets, {
-    analysis: ({ data, loopSquare }) => {
-        const [row, col] = squareToCoords(loopSquare.square);
-        const val = data.tiles[row][col].w.total.wasOn;
-        return (val * 100) / data.movesTotal;
-    },
+const heatmapData = generateHeatmap(state, ({ data, loopSquare }) => {
+    const [row, col] = squareToCoords(loopSquare.square);
+    const val = data.tiles[row][col].w.total.wasOn;
+    return (val * 100) / data.movesTotal;
 });
 ```
 
-## Options object
+## Analysis function arguments
 
 | Property     | Description                                                              |
 | ------------ | ------------------------------------------------------------------------ |

--- a/docs/content/docs/heatmaps/custom-functions.mdx
+++ b/docs/content/docs/heatmaps/custom-functions.mdx
@@ -18,6 +18,8 @@ const heatmapData = generateHeatmap(state, ({ data, loopSquare }) => {
 });
 ```
 
+Capture extra values from the outer scope when you need them (e.g. a precomputed average) — no special options field is required.
+
 ## Analysis function arguments
 
 | Property     | Description                                                              |
@@ -25,7 +27,6 @@ const heatmapData = generateHeatmap(state, ({ data, loopSquare }) => {
 | `data`       | Tracker state passed to `generateHeatmap` (e.g. `TileTrackerState`)      |
 | `loopSquare` | Info about the square being calculated                                   |
 | `refSquare`  | Info about the reference square you passed via `square` (piece heatmaps) |
-| `optData`    | Optional extra data you provide via `optData` in the options bag         |
 
 ### `loopSquare` / `refSquare` shape
 
@@ -42,7 +43,5 @@ interface SquareData {
 ```
 
 Use `refSquare` when generating heatmaps for a specific piece — e.g. white's a-pawn at `'a2'` (pass `square: 'a2'` in the options bag).
-
-Use `optData` for values your function needs but aren't on the tracker state, such as "average position after X moves."
 
 See [Presets](/docs/heatmaps/presets) for built-in functions you can study or reuse.

--- a/docs/content/docs/heatmaps/index.mdx
+++ b/docs/content/docs/heatmaps/index.mdx
@@ -12,7 +12,7 @@ import { generateHeatmap, TileHeatmapPresets, TileTracker } from 'chessalyzer/tr
 const result = await analyzePGN('<pathToPgnFile>', { trackers: [TileTracker] });
 
 const { state } = result.runs[0].trackers[0];
-const heatmapData = generateHeatmap(state, TileHeatmapPresets, { analysis: 'TILE_OCC_ALL' });
+const heatmapData = generateHeatmap(state, TileHeatmapPresets.TILE_OCC_ALL);
 printHeatmap(heatmapData);
 ```
 
@@ -22,8 +22,8 @@ printHeatmap(heatmapData);
 
 ## Options
 
-- **[Presets](/docs/heatmaps/presets)** — built-in short names like `'TILE_OCC_ALL'` for common views
+- **[Presets](/docs/heatmaps/presets)** — built-in analysis functions like `TileHeatmapPresets.TILE_OCC_ALL`
 - **[Custom functions](/docs/heatmaps/custom-functions)** — write your own per-square calculation
-- **[Comparing analyses](/docs/comparing-analyses)** — `generateComparisonHeatmap(state, otherState, presets, { analysis })` for side-by-side cohorts
+- **[Comparing analyses](/docs/comparing-analyses)** — `generateComparisonHeatmap(state, otherState, analysis)` for side-by-side cohorts
 
-Use `generateHeatmap(state, presets, options)` and `generateComparisonHeatmap(state, otherState, presets, options)` from `chessalyzer/trackers`. Pass the preset map matching your tracker state (`TileHeatmapPresets` or `PieceHeatmapPresets`).
+Use `generateHeatmap(state, analysis, options?)` and `generateComparisonHeatmap(state, otherState, analysis, options?)` from `chessalyzer/trackers`. Pass a preset from `TileHeatmapPresets` / `PieceHeatmapPresets`, or any custom function with the same signature.

--- a/docs/content/docs/heatmaps/presets.mdx
+++ b/docs/content/docs/heatmaps/presets.mdx
@@ -1,23 +1,22 @@
 ---
 title: Heatmap presets
-description: Built-in short names for common tile and piece heatmaps.
+description: Built-in analysis functions for common tile and piece heatmaps.
 ---
 
-Instead of writing your own heatmap function, pass a preset **short name** via the `analysis` option:
+Instead of writing your own heatmap function, pass a preset from `TileHeatmapPresets` or `PieceHeatmapPresets`:
 
 ```javascript
 import { generateHeatmap, TileHeatmapPresets } from 'chessalyzer/trackers';
 
 const { state } = result.runs[0].trackers[0];
 
-const heatmapData = generateHeatmap(state, TileHeatmapPresets, { analysis: 'TILE_OCC_ALL' });
-const pieceHeatmap = generateHeatmap(state, TileHeatmapPresets, {
-    analysis: 'TILE_OCC_BY_PIECE',
+const heatmapData = generateHeatmap(state, TileHeatmapPresets.TILE_OCC_ALL);
+const pieceHeatmap = generateHeatmap(state, TileHeatmapPresets.TILE_OCC_BY_PIECE, {
     square: 'a2',
 });
 ```
 
-Preset names are typed (`TileHeatmapPresetName`, `PieceHeatmapPresetName`), so `analysis` autocompletes when you pass the matching preset map.
+Preset keys are typed (`TileHeatmapPresetName`, `PieceHeatmapPresetName`), so property access on the preset map autocompletes.
 
 ## TileTracker presets
 

--- a/docs/content/docs/trackers/built-in.mdx
+++ b/docs/content/docs/trackers/built-in.mdx
@@ -50,4 +50,4 @@ Each tile has two color buckets (`b`, `w`). Each bucket has a `total` stats obje
 
 Use `total` for combined stats of one side on a square (e.g. `state.tiles[0][6].b.total.wasOn`), or `byPiece` for a single piece (e.g. `state.tiles[0][6].b.byPiece.Pa.wasOn`).
 
-`TileTracker` and `PieceTracker` support [heatmap generation](/docs/heatmaps) — pass state and the matching preset map to `generateHeatmap(state, presets, { analysis })`.
+`TileTracker` and `PieceTracker` support [heatmap generation](/docs/heatmaps) — pass state and a preset function to `generateHeatmap(state, TileHeatmapPresets.TILE_OCC_ALL)`.

--- a/manual-tests/test-heatmap.ts
+++ b/manual-tests/test-heatmap.ts
@@ -26,15 +26,10 @@ console.log(data);
 const state1 = getTrackerState(data, TileTracker, 0);
 const state2 = getTrackerState(data, TileTracker, 1);
 
+printHeatmap(generateHeatmap(state1, TileHeatmapPresets.PIECE_MOVED_TO_TILE, { square: 'd1' }));
+printHeatmap(generateHeatmap(state2, TileHeatmapPresets.PIECE_MOVED_TO_TILE, { square: 'd1' }));
 printHeatmap(
-    generateHeatmap(state1, TileHeatmapPresets, { analysis: 'PIECE_MOVED_TO_TILE', square: 'd1' }),
-);
-printHeatmap(
-    generateHeatmap(state2, TileHeatmapPresets, { analysis: 'PIECE_MOVED_TO_TILE', square: 'd1' }),
-);
-printHeatmap(
-    generateComparisonHeatmap(state1, state2, TileHeatmapPresets, {
-        analysis: 'PIECE_MOVED_TO_TILE',
+    generateComparisonHeatmap(state1, state2, TileHeatmapPresets.PIECE_MOVED_TO_TILE, {
         square: 'd1',
     }),
 );

--- a/src/trackers/heatmap-utils.ts
+++ b/src/trackers/heatmap-utils.ts
@@ -10,18 +10,6 @@ import { getStartingPiece } from '#board/piece-names';
 import type { SquareData } from '#types/game';
 import type { GenerateHeatmapOptions, HeatmapAnalysisFunc, HeatmapData } from '#types/tracker';
 
-/** Resolve a preset name or pass through a custom analysis function. */
-function resolvePreset<T, P extends string>(
-    presets: Record<P, HeatmapAnalysisFunc<T>>,
-    analysis: P | HeatmapAnalysisFunc<T>,
-): HeatmapAnalysisFunc<T> {
-    if (typeof analysis !== 'string') return analysis;
-
-    const preset = presets[analysis];
-    if (!preset) throw new Error(`Heatmap preset '${analysis}' not found!`);
-    return preset;
-}
-
 function squareData(row: number, col: number): SquareData {
     const square = coordsToSquare(row, col);
     const loopSqrCoords: BoardCoord = [row, col];
@@ -86,39 +74,32 @@ function renderHeatmap<T>(
 
 /**
  * Generate an 8×8 heatmap from tracker state.
- * `analysis` is a preset name from `presets` (autocompleted) or a custom function.
+ * `analysis` is a preset function (e.g. `TileHeatmapPresets.TILE_OCC_ALL`) or a custom function.
  */
-export function generateHeatmap<T, P extends string>(
+export function generateHeatmap<T>(
     state: T,
-    presets: Record<P, HeatmapAnalysisFunc<T>>,
-    options: GenerateHeatmapOptions<T, P>,
+    analysis: HeatmapAnalysisFunc<T>,
+    options?: GenerateHeatmapOptions,
 ): HeatmapData {
-    return renderHeatmap(
-        state,
-        resolvePreset(presets, options.analysis),
-        options.square,
-        options.optData,
-    );
+    return renderHeatmap(state, analysis, options?.square, options?.optData);
 }
 
 /**
  * Percentage-difference heatmap between two datasets.
  * Positive = `state` higher; negative = `compState` higher; zero when either cell is 0.
  */
-export function generateComparisonHeatmap<T, P extends string>(
+export function generateComparisonHeatmap<T>(
     state: T,
     compState: T,
-    presets: Record<P, HeatmapAnalysisFunc<T>>,
-    options: GenerateHeatmapOptions<T, P>,
+    analysis: HeatmapAnalysisFunc<T>,
+    options?: GenerateHeatmapOptions,
 ): HeatmapData {
-    const fun = resolvePreset(presets, options.analysis);
-
     const map: number[][] = [];
     let max = -Infinity;
     let min = Infinity;
 
-    const map0 = renderHeatmap(state, fun, options.square, options.optData);
-    const map1 = renderHeatmap(compState, fun, options.square, options.optData);
+    const map0 = renderHeatmap(state, analysis, options?.square, options?.optData);
+    const map1 = renderHeatmap(compState, analysis, options?.square, options?.optData);
 
     for (let i = 0; i < 8; i += 1) {
         const dataRow: number[] = [];

--- a/src/trackers/heatmap-utils.ts
+++ b/src/trackers/heatmap-utils.ts
@@ -38,7 +38,6 @@ function renderHeatmap<T>(
     data: T,
     fun: HeatmapAnalysisFunc<T>,
     square?: Square | BoardCoord,
-    optData?: unknown,
 ): HeatmapData {
     const refSquare = resolveRefSquare(square);
     const refRow = squareRow(refSquare);
@@ -60,7 +59,6 @@ function renderHeatmap<T>(
                 data,
                 loopSquare,
                 refSquare: refSquareData,
-                optData,
             });
             dataRow.push(heatVal);
             max = Math.max(max, heatVal);
@@ -81,7 +79,7 @@ export function generateHeatmap<T>(
     analysis: HeatmapAnalysisFunc<T>,
     options?: GenerateHeatmapOptions,
 ): HeatmapData {
-    return renderHeatmap(state, analysis, options?.square, options?.optData);
+    return renderHeatmap(state, analysis, options?.square);
 }
 
 /**
@@ -98,8 +96,8 @@ export function generateComparisonHeatmap<T>(
     let max = -Infinity;
     let min = Infinity;
 
-    const map0 = renderHeatmap(state, analysis, options?.square, options?.optData);
-    const map1 = renderHeatmap(compState, analysis, options?.square, options?.optData);
+    const map0 = renderHeatmap(state, analysis, options?.square);
+    const map1 = renderHeatmap(compState, analysis, options?.square);
 
     for (let i = 0; i < 8; i += 1) {
         const dataRow: number[] = [];

--- a/src/types/tracker.ts
+++ b/src/types/tracker.ts
@@ -75,13 +75,8 @@ export interface HeatmapAnalysisArgs<T = unknown> {
 /** Signature for built-in and custom heatmap preset functions. */
 export type HeatmapAnalysisFunc<T = unknown> = (args: HeatmapAnalysisArgs<T>) => number;
 
-/**
- * Options for `generateHeatmap` / `generateComparisonHeatmap`.
- * `P` is the preset-name union of the passed preset map, so `analysis` autocompletes.
- */
-export interface GenerateHeatmapOptions<T = unknown, P extends string = string> {
-    /** Preset name or custom analysis function. */
-    analysis: P | HeatmapAnalysisFunc<T>;
+/** Options for `generateHeatmap` / `generateComparisonHeatmap`. */
+export interface GenerateHeatmapOptions {
     /** Reference square for presets that evaluate relative to a piece/square. */
     square?: Square | BoardCoord;
     /** Extra context forwarded to the analysis function. */

--- a/src/types/tracker.ts
+++ b/src/types/tracker.ts
@@ -66,10 +66,8 @@ export interface HeatmapAnalysisArgs<T = unknown> {
     data: T;
     /** Square being evaluated in the current cell. */
     loopSquare: SquareData;
-    /** Reference square (for relative presets). */
+    /** Reference square for presets that evaluate relative to a piece/square. */
     refSquare: SquareData;
-    /** Caller-provided extra context. */
-    optData?: unknown;
 }
 
 /** Signature for built-in and custom heatmap preset functions. */
@@ -79,6 +77,4 @@ export type HeatmapAnalysisFunc<T = unknown> = (args: HeatmapAnalysisArgs<T>) =>
 export interface GenerateHeatmapOptions {
     /** Reference square for presets that evaluate relative to a piece/square. */
     square?: Square | BoardCoord;
-    /** Extra context forwarded to the analysis function. */
-    optData?: unknown;
 }

--- a/test/integration/corpus.test.ts
+++ b/test/integration/corpus.test.ts
@@ -14,7 +14,6 @@ import {
 import type {
     GameTrackerState,
     HeatmapAnalysisFunc,
-    PieceHeatmapPresetName,
     PieceTrackerState,
 } from 'chessalyzer/trackers';
 
@@ -231,8 +230,7 @@ if (corpusAvailable) {
                 });
 
                 it('PIECE_CAPTURED preset', () => {
-                    const data = generateHeatmap(state, PieceHeatmapPresets, {
-                        analysis: 'PIECE_CAPTURED',
+                    const data = generateHeatmap(state, PieceHeatmapPresets.PIECE_CAPTURED, {
                         square: 'a8',
                     });
                     expect(data.map[0]?.[0]).toBe(0);
@@ -243,8 +241,7 @@ if (corpusAvailable) {
                 });
 
                 it('PIECE_CAPTURED_BY preset', () => {
-                    const data = generateHeatmap(state, PieceHeatmapPresets, {
-                        analysis: 'PIECE_CAPTURED_BY',
+                    const data = generateHeatmap(state, PieceHeatmapPresets.PIECE_CAPTURED_BY, {
                         square: 'a8',
                     });
                     expect(data.map[0]?.[0]).toBe(0);
@@ -255,21 +252,12 @@ if (corpusAvailable) {
                 });
 
                 it('custom heatmap function', () => {
-                    const data = generateHeatmap(state, PieceHeatmapPresets, {
-                        analysis: customPieceHeatmapFunc,
+                    const data = generateHeatmap(state, customPieceHeatmapFunc, {
                         square: 'a8',
                     });
                     expect(data.map[0]?.[0]).toBe(0);
                     expect(data.map[1]?.[0]).toBe(0);
                     expect(data.map[7]?.[0]).toBe(entry.golden.pieceTracker.heatmap.custom_a8);
-                });
-
-                it('throws when preset is missing', () => {
-                    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- intentionally invalid preset name
-                    const badName = 'I_DO_NOT_EXIST' as PieceHeatmapPresetName;
-                    expect(() =>
-                        generateHeatmap(state, PieceHeatmapPresets, { analysis: badName }),
-                    ).toThrow("Heatmap preset 'I_DO_NOT_EXIST' not found!");
                 });
             });
         });

--- a/test/integration/fixtures.test.ts
+++ b/test/integration/fixtures.test.ts
@@ -201,8 +201,7 @@ describe('Fixtures', () => {
                 expect(data.gameCount).toBe(1);
                 const state = getTrackerState(data, TileTracker);
                 expect(state.movesTotal).toBe(golden.movesTotal);
-                const heat = generateHeatmap(state, TileHeatmapPresets, {
-                    analysis: 'TILE_OCC_ALL',
+                const heat = generateHeatmap(state, TileHeatmapPresets.TILE_OCC_ALL, {
                     square: 'e4',
                 });
                 expect(heat.map[4]?.[4]).toBe(golden.e4TileOccAll);


### PR DESCRIPTION
- Removes the awkward preset arg that always needed to be passed to `generateHeatmap`
- Now the function itself is passed as the argument which makes it more flexible when used with custom analysis functions