### PR TITLE
refactor: further simplify and streamline heatmap generate function and TileTracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,8 @@ Chessalyzer.js parses large PGN databases and runs user-defined **trackers** ove
 
 User-facing docs: [README Custom Trackers](README.md#custom-trackers). Trackers are **definitions** (behavior + identity) separate from **state** (plain data owned per thread). For MT (`workers` not `false`), custom trackers must:
 
-1. Live in a **separate module** with a **default export** (class adapter or factory object).
-2. Set **`id`** (instance field on class adapters) and **`workerModule = import.meta.url`** so workers can load the module.
+1. Live in a **separate module** with a **default export** (factory object from `defineGameTracker` / `defineMoveTracker`).
+2. Set **`id`** and **`workerModule = import.meta.url`** so workers can load the module.
 3. Implement **`init()`**, **`track(state, …)`**, and **`merge(state, other)`** — state is plain structured-cloneable data; only states cross the worker boundary as `TrackerSnapshot { id, state }`.
 4. Optional **`options`** (plain data) are cloned to workers before `init()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Heatmaps:** `generateHeatmap` / `generateComparisonHeatmap` take an analysis function directly (e.g. `TileHeatmapPresets.TILE_OCC_ALL` or a custom `HeatmapAnalysisFunc`). The preset map is no longer a separate argument; options are only `{ square? }` (`Square`, not `BoardCoord`). Dropped `optData` — close over outer scope instead. Removed `TileHeatmapPresetName` / `PieceHeatmapPresetName`.
+- **Custom trackers:** multithreaded modules must default-export a definition object (`defineGameTracker` / `defineMoveTracker`). Class default exports are no longer supported.
+- **`TileTrackerState`:** public type is only `{ tiles, movesTotal }` (no `movesGame` / `currentPiece`). Virtual occupants are plain objects, not a `TilePiece` class.
 
 ## [4.0.0-alpha.2] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Heatmaps:** `generateHeatmap` / `generateComparisonHeatmap` take an analysis function directly (e.g. `TileHeatmapPresets.TILE_OCC_ALL` or a custom `HeatmapAnalysisFunc`). The preset map is no longer a separate argument; options are only `{ square? }`. Dropped `optData` — close over outer scope instead.
+- **Heatmaps:** `generateHeatmap` / `generateComparisonHeatmap` take an analysis function directly (e.g. `TileHeatmapPresets.TILE_OCC_ALL` or a custom `HeatmapAnalysisFunc`). The preset map is no longer a separate argument; options are only `{ square? }` (`Square`, not `BoardCoord`). Dropped `optData` — close over outer scope instead. Removed `TileHeatmapPresetName` / `PieceHeatmapPresetName`.
 
 ## [4.0.0-alpha.2] - 2026-08-01
 

--- a/docs/content/docs/heatmaps/presets.mdx
+++ b/docs/content/docs/heatmaps/presets.mdx
@@ -16,7 +16,7 @@ const pieceHeatmap = generateHeatmap(state, TileHeatmapPresets.TILE_OCC_BY_PIECE
 });
 ```
 
-Preset keys are typed (`TileHeatmapPresetName`, `PieceHeatmapPresetName`), so property access on the preset map autocompletes.
+Preset property access on the map autocompletes in TypeScript.
 
 ## TileTracker presets
 

--- a/src/core/worker-tracker-registry.ts
+++ b/src/core/worker-tracker-registry.ts
@@ -26,19 +26,15 @@ function hasDefaultExport(module: unknown): module is { default: unknown } {
     return typeof module === 'object' && module !== null && 'default' in module;
 }
 
-/** Normalize a default export (class or def object) into a tracker definition. */
+/** Normalize a default export into a tracker definition (factory object only). */
 function normalizeDefaultExport(value: unknown): TrackerDef {
-    if (isTrackerConstructor(value)) {
-        const instance = new value();
-        assertTrackerDef(instance);
-        return instance;
+    if (typeof value === 'function') {
+        throw new Error(
+            'Custom tracker module must default-export a tracker definition object (from defineGameTracker / defineMoveTracker), not a class or function',
+        );
     }
     assertTrackerDef(value);
     return value;
-}
-
-function isTrackerConstructor(value: unknown): value is new () => TrackerDef {
-    return typeof value === 'function';
 }
 
 function createTrackerDef(id: string, options: unknown): TrackerDef {
@@ -89,7 +85,7 @@ async function loadCustomTrackers(initData: WorkerInitData | undefined): Promise
 
                 if (!hasDefaultExport(customTracker)) {
                     throw new Error(
-                        `Custom tracker "${tracker.id}" module must default-export a tracker definition or class`,
+                        `Custom tracker "${tracker.id}" module must default-export a tracker definition object`,
                     );
                 }
 

--- a/src/trackers/define-tracker.ts
+++ b/src/trackers/define-tracker.ts
@@ -41,7 +41,7 @@ function assertTrackerDefShape(tracker: object): asserts tracker is TrackerDef {
 /** Runtime validation for tracker definitions passed to analyzePGN. */
 export function assertTrackerDef(tracker: unknown): asserts tracker is TrackerDef {
     if (typeof tracker !== 'object' || tracker === null) {
-        throw new Error('Trackers must be tracker definition objects or class instances');
+        throw new Error('Trackers must be tracker definition objects');
     }
     assertTrackerDefShape(tracker);
 }

--- a/src/trackers/heatmap-utils.ts
+++ b/src/trackers/heatmap-utils.ts
@@ -1,5 +1,4 @@
 import {
-    algebraicToCoords,
     coordsToSquare,
     squareCol,
     squareRow,
@@ -19,27 +18,9 @@ function squareData(row: number, col: number): SquareData {
     };
 }
 
-function resolveRefSquare(square?: Square | BoardCoord): Square {
-    if (square === undefined) return 'a1';
-
-    if (typeof square === 'string') {
-        const resolved = algebraicToCoords(square);
-        if (resolved) {
-            return coordsToSquare(resolved[0], resolved[1]);
-        }
-        return square;
-    }
-
-    return coordsToSquare(square[0], square[1]);
-}
-
 /** Evaluate `fun` at every square and collect min/max for normalization. */
-function renderHeatmap<T>(
-    data: T,
-    fun: HeatmapAnalysisFunc<T>,
-    square?: Square | BoardCoord,
-): HeatmapData {
-    const refSquare = resolveRefSquare(square);
+function renderHeatmap<T>(data: T, fun: HeatmapAnalysisFunc<T>, square?: Square): HeatmapData {
+    const refSquare = square ?? 'a1';
     const refRow = squareRow(refSquare);
     const refCol = squareCol(refSquare);
     const refSquareData: SquareData = {

--- a/src/trackers/heatmaps/piece-heatmaps.ts
+++ b/src/trackers/heatmaps/piece-heatmaps.ts
@@ -28,5 +28,3 @@ export const PieceHeatmapPresets = {
         return captureCount(data, sqrPiece.color, sqrPiece.name, loopPiece.name);
     },
 } satisfies Record<string, HeatmapAnalysisFunc<PieceTrackerState>>;
-
-export type PieceHeatmapPresetName = keyof typeof PieceHeatmapPresets;

--- a/src/trackers/heatmaps/tile-heatmaps.ts
+++ b/src/trackers/heatmaps/tile-heatmaps.ts
@@ -47,5 +47,3 @@ export const TileHeatmapPresets = {
         return cell[piece.color].byPiece[piece.name].movedTo;
     },
 } satisfies Record<string, HeatmapAnalysisFunc<TileTrackerState>>;
-
-export type TileHeatmapPresetName = keyof typeof TileHeatmapPresets;

--- a/src/trackers/index.ts
+++ b/src/trackers/index.ts
@@ -5,11 +5,8 @@ export { PieceTracker, type PieceTrackerState } from '#trackers/piece-tracker';
 export { TileTracker, type TileTrackerState } from '#trackers/tile/tile-tracker';
 
 export { generateComparisonHeatmap, generateHeatmap } from '#trackers/heatmap-utils';
-export {
-    PieceHeatmapPresets,
-    type PieceHeatmapPresetName,
-} from '#trackers/heatmaps/piece-heatmaps';
-export { TileHeatmapPresets, type TileHeatmapPresetName } from '#trackers/heatmaps/tile-heatmaps';
+export { PieceHeatmapPresets } from '#trackers/heatmaps/piece-heatmaps';
+export { TileHeatmapPresets } from '#trackers/heatmaps/tile-heatmaps';
 
 export type { Piece } from '#trackers/piece-types';
 export { isTrackedPiece } from '#trackers/piece-types';

--- a/src/trackers/tile/tile-grid.ts
+++ b/src/trackers/tile/tile-grid.ts
@@ -10,10 +10,12 @@ import { getStartingPiece } from '#board/piece-names';
 import { pieceList } from '#trackers/piece-types';
 import {
     createColorBucket,
-    TilePiece,
+    createTilePiece,
+    type RuntimeTileGrid,
+    type RuntimeTileRow,
     type StatsField,
+    type TileCell,
     type TileGrid,
-    type TileRow,
     type TileStats,
 } from '#trackers/tile/tile-tracker-types';
 
@@ -25,16 +27,16 @@ function addTileStats(dst: TileStats, src: TileStats): void {
 }
 
 /**
- * Grid lifecycle helpers for {@link TileTrackerBase}: allocation, reset, merge.
+ * Grid lifecycle helpers for {@link TileTracker}: allocation, reset, merge.
  *
  * The tile grid is an 8×8 array of {@link StatsField} cells. Each cell contains
  * aggregate stats for black/white plus per-piece-name {@link TileStats} objects.
- * These helpers keep constructor / `add` / `onGameEnd` DRY.
+ * These helpers keep init / track / onGameEnd DRY.
  */
 
 /** Allocate a fresh 8×8 grid with zeroed stats and starting-position virtual pieces. */
-export function createTileGrid(): TileGrid {
-    function makeRow(): TileRow {
+export function createTileGrid(): RuntimeTileGrid {
+    function makeRow(): RuntimeTileRow {
         return [
             createEmptyCell(),
             createEmptyCell(),
@@ -47,7 +49,7 @@ export function createTileGrid(): TileGrid {
         ];
     }
 
-    const tiles: TileGrid = [
+    const tiles: RuntimeTileGrid = [
         makeRow(),
         makeRow(),
         makeRow(),
@@ -80,9 +82,9 @@ function createEmptyCell(): StatsField {
  * Place the standard starting virtual piece on `(row, col)`, or clear the cell.
  * Board coords: row 0 = rank 8, row 7 = rank 1.
  */
-export function setStartingPiece(tiles: TileGrid, row: BoardIndex, col: BoardIndex): void {
+export function setStartingPiece(tiles: RuntimeTileGrid, row: BoardIndex, col: BoardIndex): void {
     const piece = getStartingPiece([row, col]);
-    tiles[row][col].currentPiece = piece ? new TilePiece(piece.name, piece.color) : null;
+    tiles[row][col].currentPiece = piece ? createTilePiece(piece.name, piece.color) : null;
 }
 
 /**
@@ -100,7 +102,12 @@ export function mergeCellStats(dst: StatsField, src: StatsField): void {
 }
 
 /** Resolve an interned {@link Square} to a grid cell when indices are in range. */
-export function tileCellAt(tiles: TileGrid, square: Square): StatsField | undefined {
+export function tileCellAt(tiles: RuntimeTileGrid, square: Square): StatsField | undefined;
+export function tileCellAt(tiles: TileGrid, square: Square): TileCell | undefined;
+export function tileCellAt(
+    tiles: TileGrid | RuntimeTileGrid,
+    square: Square,
+): TileCell | StatsField | undefined {
     const row = squareRow(square);
     const col = squareCol(square);
     if (!isBoardIndex(row) || !isBoardIndex(col)) {

--- a/src/trackers/tile/tile-tracker-types.ts
+++ b/src/trackers/tile/tile-tracker-types.ts
@@ -1,5 +1,5 @@
 /**
- * Data model for {@link TileTrackerBase}: per-square stats and virtual piece tracking.
+ * Data model for {@link TileTracker}: per-square stats and virtual piece tracking.
  *
  * Piece names come from the canonical starting-position templates (via `piece-list`).
  * All tracker state is plain data (no class instances) so it survives structured
@@ -38,30 +38,36 @@ export function createColorBucket(): ColorBucket {
     return { total: createTileStats(), byPiece };
 }
 
+/** Public per-square counters (what callers see on {@link TileTrackerState.tiles}). */
+export interface TileCell {
+    b: ColorBucket;
+    w: ColorBucket;
+}
+
 /**
  * Virtual piece used for occupation tracking — not the same as board {@link ChessPiece}.
  * `lastMovedOn` stores the move index when this piece last arrived on its square.
  */
-export class TilePiece {
+export interface TilePiece {
     piece: string;
     color: 'b' | 'w';
     lastMovedOn: number;
-
-    constructor(piece: string, color: 'b' | 'w') {
-        this.piece = piece;
-        this.color = color;
-        this.lastMovedOn = 0;
-    }
 }
 
-/** One cell of the 8×8 tile grid: color aggregates, per-piece stats, and current occupant. */
-export interface StatsField {
-    b: ColorBucket;
-    w: ColorBucket;
+export function createTilePiece(piece: string, color: 'b' | 'w'): TilePiece {
+    return { piece, color, lastMovedOn: 0 };
+}
+
+/** Runtime cell: public counters plus live occupant for occupation tracking. */
+export interface StatsField extends TileCell {
     currentPiece: TilePiece | null;
 }
 
-export type TileRow = [
+type TileRow = [TileCell, TileCell, TileCell, TileCell, TileCell, TileCell, TileCell, TileCell];
+
+export type TileGrid = [TileRow, TileRow, TileRow, TileRow, TileRow, TileRow, TileRow, TileRow];
+
+export type RuntimeTileRow = [
     StatsField,
     StatsField,
     StatsField,
@@ -72,4 +78,13 @@ export type TileRow = [
     StatsField,
 ];
 
-export type TileGrid = [TileRow, TileRow, TileRow, TileRow, TileRow, TileRow, TileRow, TileRow];
+export type RuntimeTileGrid = [
+    RuntimeTileRow,
+    RuntimeTileRow,
+    RuntimeTileRow,
+    RuntimeTileRow,
+    RuntimeTileRow,
+    RuntimeTileRow,
+    RuntimeTileRow,
+    RuntimeTileRow,
+];

--- a/src/trackers/tile/tile-tracker.ts
+++ b/src/trackers/tile/tile-tracker.ts
@@ -13,15 +13,23 @@ import {
     setStartingPiece,
     tileCellAt,
 } from '#trackers/tile/tile-grid';
-import type { TileGrid } from '#trackers/tile/tile-tracker-types';
+import type { RuntimeTileGrid, TileGrid } from '#trackers/tile/tile-tracker-types';
 import type { Action } from '#types/actions';
 import type { MoveCoords } from '#types/game';
 import type { PlayerColor } from '#types/tokens';
+import type { MoveTrackerDef } from '#types/tracker';
 
+/** Public TileTracker result: square counters and total move count (no per-game scratch). */
 export interface TileTrackerState {
     tiles: TileGrid;
-    movesGame: number;
     movesTotal: number;
+}
+
+/** Internal state used while tracking — includes occupation scratch fields. */
+interface TileTrackerRuntimeState {
+    tiles: RuntimeTileGrid;
+    movesTotal: number;
+    movesGame: number;
 }
 
 function isCastleRookLeg(action: Action): boolean {
@@ -36,11 +44,11 @@ function isCastleRookLeg(action: Action): boolean {
  * Add `(movesGame - lastMovedOn)` to wasOn for the piece currently on `pos`.
  * Measures how many half-moves the piece occupied the square since it arrived.
  */
-function addOccupation(state: TileTrackerState, pos: Square): void {
+function addOccupation(state: TileTrackerRuntimeState, pos: Square): void {
     addOccupationByRowCol(state, squareRow(pos), squareCol(pos));
 }
 
-function addOccupationByRowCol(state: TileTrackerState, row: number, col: number): void {
+function addOccupationByRowCol(state: TileTrackerRuntimeState, row: number, col: number): void {
     if (!isBoardIndex(row) || !isBoardIndex(col)) return;
     const cell = state.tiles[row][col];
     const { currentPiece } = cell;
@@ -59,7 +67,7 @@ function addOccupationByRowCol(state: TileTrackerState, row: number, col: number
  * increment movedTo counters. Skips promoted pawns (digit-suffixed names).
  */
 function processMove(
-    state: TileTrackerState,
+    state: TileTrackerRuntimeState,
     move: MoveCoords,
     player: PlayerColor,
     piece: string | null | undefined,
@@ -100,7 +108,7 @@ function processMove(
  * Taken piece occupation is flushed before clearing the square.
  */
 function processCapture(
-    state: TileTrackerState,
+    state: TileTrackerRuntimeState,
     pos: Square,
     player: PlayerColor,
     takingPiece: string | null | undefined,
@@ -132,7 +140,7 @@ function processCapture(
  * Maintains a virtual 8×8 grid ({@link StatsField}) parallel to the board replay.
  * Grid allocation/reset/merge lives in `./tile-grid`.
  */
-export const TileTracker = defineMoveTracker<TileTrackerState>({
+const tileTrackerDef = defineMoveTracker<TileTrackerRuntimeState>({
     id: 'TileTracker',
 
     init: () => ({
@@ -200,3 +208,6 @@ export const TileTracker = defineMoveTracker<TileTrackerState>({
         state.movesGame = 0;
     },
 });
+
+/** Public tracker definition — result state is typed without runtime scratch fields. */
+export const TileTracker: MoveTrackerDef<TileTrackerState> = tileTrackerDef;

--- a/src/types/tracker.ts
+++ b/src/types/tracker.ts
@@ -1,4 +1,4 @@
-import type { BoardCoord, Square } from '#board/board-coords';
+import type { Square } from '#board/board-coords';
 import type { Action } from '#types/actions';
 import type { SquareData } from '#types/game';
 import type { ParsedGame } from '#types/parse-pgn';
@@ -76,5 +76,5 @@ export type HeatmapAnalysisFunc<T = unknown> = (args: HeatmapAnalysisArgs<T>) =>
 /** Options for `generateHeatmap` / `generateComparisonHeatmap`. */
 export interface GenerateHeatmapOptions {
     /** Reference square for presets that evaluate relative to a piece/square. */
-    square?: Square | BoardCoord;
+    square?: Square;
 }

--- a/test/helpers/tracker-state.ts
+++ b/test/helpers/tracker-state.ts
@@ -4,13 +4,7 @@ import type { TileTrackerState } from 'chessalyzer/trackers';
 import type { CustomGameTrackerState } from '~/test/fixtures/custom-game-tracker';
 
 export function isTileTrackerState(value: unknown): value is TileTrackerState {
-    return (
-        typeof value === 'object' &&
-        value !== null &&
-        'movesTotal' in value &&
-        'movesGame' in value &&
-        'tiles' in value
-    );
+    return typeof value === 'object' && value !== null && 'movesTotal' in value && 'tiles' in value;
 }
 
 export function isPieceTrackerState(value: unknown): value is PieceTrackerState {


### PR DESCRIPTION
- Make square only be of type Square; drop BoardCoord union (generateHeatmap)
- Drop class-based Trackers
- Drop internal state from returned TileTracker data