### PR TITLE
test: enforce cleaner split between unit and integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,13 +119,14 @@ Place large Lichess exports in `pgn/` (gitignored). The perf bench automatically
 
 ### Tests
 
-- **Unit tests** — colocated under `src/<module>/__tests__/` next to the code they cover (e.g. `src/core/__tests__/worker-pool.test.ts`). Prefer `#` import aliases.
-- **Integration tests** — `test/integration/` against the built package (`chessalyzer`). See [`test/README.md`](test/README.md) for fixtures vs corpus.
+- **Unit tests** — colocated under `src/<module>/__tests__/` next to the code they cover. Import SUT via `#` aliases only (no `chessalyzer`). Run with `bun run test:unit` (no build).
+- **Integration tests** — `test/integration/` against the built package (`chessalyzer`). Require `bun run build` first (`bun run test:integration`). See [`test/README.md`](test/README.md) for import rules, fixtures vs corpus.
 
 ```bash
-npm test
-npm run typecheck
-npm run lint
+bun run test:unit
+bun run build && bun run test:integration
+bun run typecheck
+bun run lint
 ```
 
-Run the full test suite after functional changes.
+Run the full test suite after functional changes (`bun run build && bun test`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Examples of deliberate choices:
 - **Readline `'line'` events instead of `for await`** in `openLineStream` / `readLines` — sync push handlers beat async-iterator pull on large PGNs; `await` only at chunk boundaries in `readPgnChunks`. See `bench/exploratory/line-reader-readline.ts`. Do not reintroduce per-line async iteration for “cleaner” ergonomics.
 - **Worker-side parsing** with transferable UTF-8 chunk bytes to minimize main-thread work and copying.
 - **Zero production dependencies.**
-- **`AssembledGame` (`moves: string[]`) vs public `ParsedGame` (`moves: ParsedMove[]`)** — the analyze/replay pipeline keeps mainline SANs as strings (`GameAssembler`, `GameReplayer`, workers). `{ san }` objects are materialized only at public boundaries (`parsePGN`, `streamParsePGN`, game trackers, filters) via `toParsedGame()` in [`src/types/parse-pgn.ts`](src/types/parse-pgn.ts). **Do not collapse this into `ParsedMove[]` everywhere** for API neatness: v4 alpha benching showed only ~1–2% regression on `replay: 'skip'` but a large regression on `replay: 'board'`, because board replay loads every move in a tight loop — `moves[i].san` (object + property) vs `moves[i]` (string). Millions of short-lived `{ san }` allocations also add GC pressure during CPU-bound replay. Re-benchmarking this split is unnecessary unless the move representation or hot-path consumers change.
+- **`AssembledGame` (`moves: string[]`) vs public `ParsedGame` (`moves: ParsedMove[]`)** — the analyze/replay pipeline keeps mainline SANs as strings (`GameAssembler`, `GameReplayer`, workers). `{ san }` objects are materialized only at public boundaries (`parsePGN`, `streamParsePGN`, game trackers, filters) via `toParsedGame()` in [`src/types/parse-pgn.ts`](src/types/parse-pgn.ts). **Do not collapse this into `ParsedMove[]` everywhere** for API neatness: v4 alpha benching showed only ~1–2% regression on `replay: 'skip'` but a large regression on `replay: 'board'`, because board replay loads every move in a tight loop — `moves[i].san` (object + property) vs `moves[i]` (string). Millions of short-lived `{ san }` allocations also add GC pressure during CPU-bound replay.
 
 ### Rules for agents
 
@@ -80,11 +80,13 @@ Examples of deliberate choices:
 
 ### Benchmarks
 
-| Command                         | Purpose                                                                |
-| ------------------------------- | ---------------------------------------------------------------------- |
-| `npm run bench:perf`            | **Primary regression check** — full `analyzePGN` on a large cached PGN |
-| `npm run bench:perf:bun`        | Same, on Bun                                                           |
-| `npm run bench:atomic -- array` | Array append micro-benchmarks                                          |
+Run `bench:perf` when performance-sensitive code changes, in all `skip`, `board` and `actions` mode (see below). Always run the scripts sequentially to not skew the results. If the results of the bench are inconclusive, check back with the user first instead of directly reverting the change that is being benchmarked.
+
+| Command                                       | Purpose                                                                |
+| --------------------------------------------- | ---------------------------------------------------------------------- |
+| `bun run bench:perf [skip,board,actions]`     | **Primary regression check** — full `analyzePGN` on a large cached PGN |
+| `bun run bench:perf:bun [skip,board,actions]` | Same, on Bun                                                           |
+| `bun run bench:atomic -- array`               | Array append micro-benchmarks                                          |
 
 **Exploratory scripts** (run directly with `bun bench/exploratory/<name>.ts`):
 
@@ -126,4 +128,4 @@ npm run typecheck
 npm run lint
 ```
 
-Run tests after functional changes. Run `bench:perf` when performance-sensitive code changes.
+Run the full test suite after functional changes.

--- a/bench/bench-perf.ts
+++ b/bench/bench-perf.ts
@@ -10,8 +10,8 @@
  *   - board — same plus internal board replay (`replay: 'board'`)
  *
  * Run:
- *   npm run bench:perf
- *   npm run bench:perf:bun
+ *   bun run bench:perf [skip,board,actions] (--single-threaded (optional))
+ *   bun run bench:perf:bun [skip,board,actions] (--single-threaded (optional))
  *
  * Pass `single-threaded` to benchmark only the single-threaded path.
  *
@@ -33,13 +33,16 @@ import {
 
 const RUNS = Number(process.env.BENCH_RUNS ?? 2);
 const WARMUP = process.env.BENCH_WARMUP !== '0';
-const isSingleThreaded = process.argv.includes('single-threaded');
-const replayModes = process.argv.slice(2).filter((arg) => !arg.startsWith('--'));
+const isSingleThreaded = process.argv.includes('--single-threaded');
+const allowedReplayModes = ['skip', 'board', 'actions'];
+const replayModes = process.argv.slice(2).filter((arg) => allowedReplayModes.includes(arg));
 
-/** Count-only replay modes exercised by this bench (no move trackers). */
-const SCENARIOS = (
-    replayModes.length > 0 ? replayModes : ['skip', 'board']
-) as readonly ReplayMode[];
+if (replayModes.length === 0) {
+    console.error('Error: No replay modes provided');
+    console.error('Usage: bun run bench:perf [skip|board]...');
+    process.exit(1);
+}
+const SCENARIOS = replayModes as readonly ReplayMode[];
 
 interface AnalyzeSample {
     games: number;

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "lint": "oxlint",
         "format": "oxfmt",
         "typecheck": "tsc --noEmit",
-        "knip": "knip",
+        "knip": "knip-bun",
         "bench:perf": "tsx bench/bench-perf.ts",
         "bench:perf:bun": "bun bench/bench-perf.ts",
         "bench:atomic": "tsx bench/bench-atomic.ts",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "scripts": {
         "build": "bun scripts/create-bundle.ts",
         "test": "bun test",
+        "test:unit": "bun test src",
+        "test:integration": "bun test test/integration",
         "test:build-fixtures": "bun run build && bun scripts/build-fixture-manifest.ts",
         "lint": "oxlint",
         "format": "oxfmt",

--- a/src/core/__tests__/fixtures/merge-game-tracker.ts
+++ b/src/core/__tests__/fixtures/merge-game-tracker.ts
@@ -1,0 +1,44 @@
+/**
+ * Source-only game tracker for unit merge tests.
+ *
+ * Unlike `test/fixtures/custom-game-tracker.ts` (package imports + workerModule,
+ * models the public MT contract), this stub stays on `#` so `bun test src` needs
+ * no build. Merge logic under test does not require workerModule.
+ */
+import { defineGameTracker } from '#trackers/define-tracker';
+import type { ParsedGame } from '#types/parse-pgn';
+
+export interface MergeGameTrackerState {
+    wins: [number, number, number];
+    games: number;
+}
+
+export default defineGameTracker<MergeGameTrackerState>({
+    id: 'MergeGameTracker',
+
+    init: () => ({ wins: [0, 0, 0], games: 0 }),
+
+    track(state, game: ParsedGame) {
+        state.games += 1;
+        switch (game.result) {
+            case '1-0':
+                state.wins[0] += 1;
+                break;
+            case '1/2-1/2':
+                state.wins[1] += 1;
+                break;
+            case '0-1':
+                state.wins[2] += 1;
+                break;
+            default:
+                break;
+        }
+    },
+
+    merge(state, other) {
+        state.wins[0] += other.wins[0];
+        state.wins[1] += other.wins[1];
+        state.wins[2] += other.wins[2];
+        state.games += other.games;
+    },
+});

--- a/src/core/__tests__/fixtures/merge-game-tracker.ts
+++ b/src/core/__tests__/fixtures/merge-game-tracker.ts
@@ -8,7 +8,7 @@
 import { defineGameTracker } from '#trackers/define-tracker';
 import type { ParsedGame } from '#types/parse-pgn';
 
-export interface MergeGameTrackerState {
+interface MergeGameTrackerState {
     wins: [number, number, number];
     games: number;
 }

--- a/src/core/__tests__/fixtures/stub-error-worker.ts
+++ b/src/core/__tests__/fixtures/stub-error-worker.ts
@@ -1,0 +1,17 @@
+/**
+ * Stub worker that always reports a batch error via `result.error`.
+ * Used to assert WorkerPool rejects runTask (and does not hang) without depending
+ * on chess-worker / tracker registry.
+ */
+import assert from 'node:assert';
+import { parentPort } from 'node:worker_threads';
+
+assert(parentPort, 'stub-error-worker must run as a worker thread');
+const port = parentPort;
+
+port.on('message', () => {
+    port.postMessage({
+        results: [],
+        error: 'Unknown tracker "DoesNotExist"',
+    });
+});

--- a/src/core/__tests__/fixtures/stub-worker.ts
+++ b/src/core/__tests__/fixtures/stub-worker.ts
@@ -1,0 +1,16 @@
+/**
+ * Minimal worker for WorkerPool unit tests.
+ *
+ * Intentionally not the production chess-worker: pool mechanics (lazy spawn,
+ * missing-file errors, successful message handling) should not depend on a build
+ * or on tracker registry behavior (covered in worker-tracker-registry).
+ */
+import assert from 'node:assert';
+import { parentPort } from 'node:worker_threads';
+
+assert(parentPort, 'stub-worker must run as a worker thread');
+const port = parentPort;
+
+port.on('message', () => {
+    port.postMessage({ results: [{ idxConfig: 0, games: 0, moves: 0 }] });
+});

--- a/src/core/__tests__/tracker-merge.test.ts
+++ b/src/core/__tests__/tracker-merge.test.ts
@@ -4,8 +4,9 @@ import { TrackerHost } from '#core/tracker-host';
 import { createWorkerResultHandler, mergeWorkerTrackerFlush } from '#core/tracker-merge';
 import { TileTracker } from '#trackers/tile/tile-tracker';
 import type { GameProcessorAnalysisConfigFull } from '#types/analysis-runtime';
-import CustomGameTracker from '~/test/fixtures/custom-game-tracker';
-import { isCustomGameTrackerState, isTileTrackerState } from '~/test/helpers/tracker-state';
+import { isGameWinsTrackerState, isTileTrackerState } from '~/test/helpers/tracker-state';
+
+import MergeGameTracker from './fixtures/merge-game-tracker';
 
 function baseConfig(
     overrides?: Partial<GameProcessorAnalysisConfigFull>,
@@ -50,16 +51,16 @@ describe('tracker merge', () => {
         });
     });
 
-    describe('CustomGameTracker.merge', () => {
+    describe('MergeGameTracker.merge', () => {
         it('sums wins and game counts from a partial batch', () => {
-            const customTracker = CustomGameTracker;
-            const mainHost = new TrackerHost([customTracker]);
-            const batchHost = new TrackerHost([customTracker]);
+            const tracker = MergeGameTracker;
+            const mainHost = new TrackerHost([tracker]);
+            const batchHost = new TrackerHost([tracker]);
 
             const mainState = mainHost.gameEntries[0]?.state;
             const batchState = batchHost.gameEntries[0]?.state;
-            if (!isCustomGameTrackerState(mainState) || !isCustomGameTrackerState(batchState)) {
-                throw new Error('expected custom game tracker state');
+            if (!isGameWinsTrackerState(mainState) || !isGameWinsTrackerState(batchState)) {
+                throw new Error('expected merge game tracker state');
             }
 
             mainState.wins = [2, 1, 3];
@@ -90,9 +91,9 @@ describe('tracker merge', () => {
         });
 
         it('merges worker batch counters without tracker state', () => {
-            const customTracker = CustomGameTracker;
+            const tracker = MergeGameTracker;
             const cfg = baseConfig({
-                trackerHost: new TrackerHost([customTracker]),
+                trackerHost: new TrackerHost([tracker]),
                 config: { maxGames: 10 },
             });
 
@@ -113,15 +114,15 @@ describe('tracker merge', () => {
             expect(cfg.processedGames).toBe(2);
             expect(cfg.processedMoves).toBe(40);
             const state = cfg.trackerHost.gameEntries[0]?.state;
-            if (!isCustomGameTrackerState(state)) {
-                throw new Error('expected custom game tracker state');
+            if (!isGameWinsTrackerState(state)) {
+                throw new Error('expected merge game tracker state');
             }
             expect(state.games).toBe(0);
         });
 
         it('merges multi-config batch results', () => {
-            const trackerA = CustomGameTracker;
-            const trackerB = CustomGameTracker;
+            const trackerA = MergeGameTracker;
+            const trackerB = MergeGameTracker;
 
             const cfgA = baseConfig({
                 trackerHost: new TrackerHost([trackerA]),

--- a/src/core/__tests__/worker-pool.test.ts
+++ b/src/core/__tests__/worker-pool.test.ts
@@ -1,14 +1,13 @@
 import { describe, it, expect, afterEach } from 'bun:test';
-import { join } from 'node:path';
 
 import WorkerPool from '#core/worker-pool';
 import type { WorkerMessage } from '#types/worker';
 
 /** Valid stub — only used once a worker is actually spawned. */
-const stubWorkerPath = join(import.meta.dirname, 'fixtures/stub-worker.ts');
-const stubErrorWorkerPath = join(import.meta.dirname, 'fixtures/stub-error-worker.ts');
+const stubWorkerPath = new URL('fixtures/stub-worker.ts', import.meta.url).pathname;
+const stubErrorWorkerPath = new URL('fixtures/stub-error-worker.ts', import.meta.url).pathname;
 /** Guaranteed missing — used to prove filePath is validated at spawn time. */
-const missingWorkerPath = join(import.meta.dirname, 'fixtures/does-not-exist-worker.ts');
+const missingWorkerPath = new URL('fixtures/does-not-exist-worker.ts', import.meta.url).pathname;
 
 function minimalChunkBytes(): Uint8Array {
     // Fresh buffer per task: WorkerPool transfers the ArrayBuffer, which detaches it.

--- a/src/core/__tests__/worker-pool.test.ts
+++ b/src/core/__tests__/worker-pool.test.ts
@@ -2,9 +2,40 @@ import { describe, it, expect, afterEach } from 'bun:test';
 import { join } from 'node:path';
 
 import WorkerPool from '#core/worker-pool';
+import type { WorkerMessage } from '#types/worker';
 
-// TODO: Check if path works
-const workerPath = join(import.meta.dirname, '~/src/chess-worker.js');
+/** Valid stub — only used once a worker is actually spawned. */
+const stubWorkerPath = join(import.meta.dirname, 'fixtures/stub-worker.ts');
+const stubErrorWorkerPath = join(import.meta.dirname, 'fixtures/stub-error-worker.ts');
+/** Guaranteed missing — used to prove filePath is validated at spawn time. */
+const missingWorkerPath = join(import.meta.dirname, 'fixtures/does-not-exist-worker.ts');
+
+function minimalChunkBytes(): Uint8Array {
+    // Fresh buffer per task: WorkerPool transfers the ArrayBuffer, which detaches it.
+    return new TextEncoder().encode('[Event "t"]\n\n1. e4 1-0\n');
+}
+
+const emptyInit = {
+    configs: [{ trackerData: [] as { id: string }[], replayMode: 'skip' as const }],
+};
+
+async function runTaskWithTimeout(
+    pool: WorkerPool,
+    task: Parameters<WorkerPool['runTask']>[0],
+    timeoutMs: number,
+): Promise<{ err: Error | null; result: WorkerMessage | null }> {
+    const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('WorkerPool task timed out')), timeoutMs),
+    );
+    const settled = pool.runTask(task).then(
+        (result) => ({ err: null, result }),
+        (err: unknown) => ({
+            err: err instanceof Error ? err : new Error(String(err)),
+            result: null,
+        }),
+    );
+    return Promise.race([settled, timeout]);
+}
 
 describe('WorkerPool', () => {
     let pool: WorkerPool | undefined;
@@ -15,9 +46,61 @@ describe('WorkerPool', () => {
     });
 
     it('does not spawn workers until the first runTask', () => {
-        pool = new WorkerPool(8, workerPath, {
-            configs: [{ trackerData: [], replayMode: 'skip' }],
-        });
+        // filePath is unused until pump() → addNewWorker(); a missing path must
+        // not affect this assertion (see the following test for spawn failure).
+        pool = new WorkerPool(8, missingWorkerPath, emptyInit);
         expect(pool.workers.length).toBe(0);
+    });
+
+    it('rejects when the worker file path does not exist', async () => {
+        pool = new WorkerPool(1, missingWorkerPath, emptyInit);
+
+        const { err } = await runTaskWithTimeout(
+            pool,
+            {
+                pgnChunkBytes: minimalChunkBytes(),
+                configs: [{ idxConfig: 0, parseHeaders: false }],
+            },
+            10_000,
+        );
+
+        expect(err).toBeInstanceOf(Error);
+        expect(err?.message.length).toBeGreaterThan(0);
+        expect(pool.failed).toBe(true);
+    });
+
+    it('resolves runTask for a successful stub worker', async () => {
+        pool = new WorkerPool(1, stubWorkerPath, emptyInit);
+
+        const { err, result } = await runTaskWithTimeout(
+            pool,
+            {
+                pgnChunkBytes: minimalChunkBytes(),
+                configs: [{ idxConfig: 0, parseHeaders: false }],
+            },
+            10_000,
+        );
+
+        expect(err).toBeNull();
+        expect(result?.error).toBeUndefined();
+        expect(result?.results).toEqual([{ idxConfig: 0, games: 0, moves: 0 }]);
+    });
+
+    it('rejects runTask when the worker posts result.error (does not hang)', async () => {
+        pool = new WorkerPool(1, stubErrorWorkerPath, emptyInit);
+
+        const { err, result } = await runTaskWithTimeout(
+            pool,
+            {
+                pgnChunkBytes: minimalChunkBytes(),
+                configs: [{ idxConfig: 0, parseHeaders: false }],
+            },
+            10_000,
+        );
+
+        expect(err).toBeInstanceOf(Error);
+        expect(err?.message).toContain('Unknown tracker');
+        expect(result).toBeNull();
+        expect(pool.failed).toBe(true);
     });
 });

--- a/test/README.md
+++ b/test/README.md
@@ -72,4 +72,4 @@ CI (`.github/workflows/ci.yml`) runs `bun run build` then `bun test`. Corpus tes
 
 ## Optional local checks
 
-- **Perf regression:** `npm run bench:perf` when a large PGN is available under `pgn/` (not run in default CI)
+- **Perf regression:** `bun run bench:perf` when a large PGN is available under `pgn/` (not run in default CI)

--- a/test/README.md
+++ b/test/README.md
@@ -10,6 +10,27 @@ test/corpus/                Large PGN files (gitignored, optional)
 test/helpers/               Shared test utilities
 ```
 
+## Import rules
+
+Never mix `#…` and `chessalyzer` in the same test file.
+
+| Layer                                            | Import the code under test from                            | Notes                                                                                         |
+| ------------------------------------------------ | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Unit (`src/**/__tests__`)                        | `#…` → source                                              | No `chessalyzer` imports (not even transitively via fixtures). `bun test src` needs no build. |
+| Integration (`test/integration`)                 | `chessalyzer` / `chessalyzer/pgn` / `chessalyzer/trackers` | Asserts the published package graph. Requires `bun run build` first.                          |
+| Shared helpers (`test/helpers`)                  | `#…` for types/shapes; stay package-free at runtime        | Helpers assert shapes, not package exports.                                                   |
+| Package-contract fixtures (`test/fixtures/*.ts`) | `chessalyzer/*`                                            | Models the public custom-tracker MT contract (`workerModule`, etc.). Integration only.        |
+| Manual release (`manual-tests/test-release*.ts`) | `chessalyzer`                                              | Smoke against the built package.                                                              |
+| Manual dev (`manual-tests/test-dev.ts`)          | `#…`                                                       | Local source smoke without a build.                                                           |
+
+Use `~/test/…` (tsconfig `paths`) for fixture/helper paths. Prefer `fixturePath(…)` from `~/test/helpers/fixtures` over ad-hoc relative paths.
+
+### Non-obvious choices
+
+- **Custom tracker fixtures are split.** `test/fixtures/custom-game-tracker.ts` uses package imports + `workerModule` (user-facing MT contract). Unit merge tests use `src/core/__tests__/fixtures/merge-game-tracker.ts` on `#` instead — merge logic does not need `workerModule`, and sharing the package fixture would force a build for unit tests.
+- **WorkerPool unit tests use stub workers**, not `lib/chess-worker.js`. Pool mechanics (lazy spawn, missing file, `result.error` → reject) are independent of tracker registry; unknown-tracker init is covered in `worker-tracker-registry.test.ts`. Production MT abort / corrupt PGN stay in integration via `analyzePGN`.
+- **Lazy spawn vs missing path.** Constructing `WorkerPool` does not touch `filePath`. The unit suite uses a deliberately missing path for the lazy-spawn case, then a separate test that `runTask` fails when the file is missing — so “path unused until spawn” is not confused with “path wrong but green.”
+
 ### Colocated unit tests
 
 Module-specific tests live next to the code they exercise (e.g. `src/pgn/__tests__/pgn-chunk.test.ts` tests chunk alignment and parsing). This makes it obvious which source file a failure relates to.
@@ -22,7 +43,7 @@ Tests that run the full `analyzePGN` pipeline stay in `test/integration/` becaus
 | ------------------------ | -------------------------------------------------------------------- |
 | `fixtures.test.ts`       | Small PGN fixtures, filters, TileTracker golden                      |
 | `parse-pgn.test.ts`      | `chessalyzer/pgn` `parsePGN` / `streamParsePGN`, fixture move counts |
-| `workers.test.ts`        | WorkerPool error propagation, MT abort                               |
+| `workers.test.ts`        | MT `analyzePGN` abort / corrupt trailing game                        |
 | `custom-tracker.test.ts` | Custom tracker + `workerModule` in MT mode                           |
 | `error-policy.test.ts`   | `onError: 'abort'` / `'skip-game'`                                   |
 | `corpus.test.ts`         | Optional large-file golden regression                                |
@@ -53,7 +74,7 @@ Corpus tests use `describe.skip` when `test/corpus/asorted-games.pgn` is missing
 | Replay unit                          | yes             | —             | `src/replay/__tests__/game-replayer.test.ts` |
 | Error skip-game                      | yes             | yes           | `error-policy.test.ts`                       |
 | Error abort                          | yes             | yes           | `error-policy.test.ts`, `workers.test.ts`    |
-| Worker error propagation             | —               | yes           | `workers.test.ts`, `tracker-merge.test.ts`   |
+| WorkerPool unit                      | —               | —             | `src/core/__tests__/worker-pool.test.ts`     |
 | Tracker merge unit                   | —               | —             | `src/core/__tests__/tracker-merge.test.ts`   |
 
 **Corpus-only gaps:** GameTracker ECO totals, PieceTracker heatmaps, and large-scale filter counts require `test/corpus/asorted-games.pgn`.
@@ -61,8 +82,9 @@ Corpus tests use `describe.skip` when `test/corpus/asorted-games.pgn` is missing
 ## Commands
 
 ```sh
-bun run build                # required before integration tests (CI runs this automatically)
-bun test                     # fixtures + unit tests (CI default)
+bun run test:unit            # src/** only — no build required
+bun run build && bun run test:integration   # built package contract
+bun run build && bun test    # full suite (CI: setup builds, then bun test)
 bun run test:build-fixtures  # merge-update manifest after fixture changes (preserves golden)
 ```
 

--- a/test/fixtures/custom-game-tracker.ts
+++ b/test/fixtures/custom-game-tracker.ts
@@ -1,7 +1,7 @@
 import type { ParsedGame } from 'chessalyzer/pgn';
 import { defineGameTracker } from 'chessalyzer/trackers';
 
-export interface CustomGameTrackerState {
+interface CustomGameTrackerState {
     wins: [number, number, number];
     games: number;
 }

--- a/test/helpers/tracker-state.ts
+++ b/test/helpers/tracker-state.ts
@@ -1,7 +1,17 @@
-import type { PieceTrackerState } from 'chessalyzer/trackers';
-import type { TileTrackerState } from 'chessalyzer/trackers';
+/**
+ * Structural type guards for tracker state in tests.
+ *
+ * Types come from `#` (source) so unit tests stay build-free. Integration tests
+ * may still use these helpers; they assert shapes, not the package export graph.
+ */
+import type { PieceTrackerState } from '#trackers/piece-tracker';
+import type { TileTrackerState } from '#trackers/tile/tile-tracker';
 
-import type { CustomGameTrackerState } from '~/test/fixtures/custom-game-tracker';
+/** Shared shape for custom / merge game-tracker stubs (wins + games). */
+export interface GameWinsTrackerState {
+    wins: [number, number, number];
+    games: number;
+}
 
 export function isTileTrackerState(value: unknown): value is TileTrackerState {
     return typeof value === 'object' && value !== null && 'movesTotal' in value && 'tiles' in value;
@@ -11,7 +21,7 @@ export function isPieceTrackerState(value: unknown): value is PieceTrackerState 
     return typeof value === 'object' && value !== null && 'b' in value && 'w' in value;
 }
 
-export function isCustomGameTrackerState(value: unknown): value is CustomGameTrackerState {
+export function isGameWinsTrackerState(value: unknown): value is GameWinsTrackerState {
     if (typeof value !== 'object' || value === null) return false;
     const wins = Reflect.get(value, 'wins');
     return 'games' in value && Array.isArray(wins);

--- a/test/integration/corpus.test.ts
+++ b/test/integration/corpus.test.ts
@@ -8,6 +8,7 @@ import type { ParsedGame } from 'chessalyzer/pgn';
 import {
     GameTracker,
     generateHeatmap,
+    isTrackedPiece,
     PieceHeatmapPresets,
     PieceTracker,
 } from 'chessalyzer/trackers';
@@ -17,7 +18,6 @@ import type {
     PieceTrackerState,
 } from 'chessalyzer/trackers';
 
-import { isTrackedPiece } from '#trackers/piece-types';
 import { corpusPath, getCorpusEntry } from '~/test/helpers/fixtures';
 import { isPieceTrackerState } from '~/test/helpers/tracker-state';
 

--- a/test/integration/workers.test.ts
+++ b/test/integration/workers.test.ts
@@ -1,97 +1,39 @@
-import { describe, it, expect, afterEach } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { join } from 'node:path';
 
 import { analyzePGN, getTrackerState } from 'chessalyzer';
 import { PieceTracker, TileTracker } from 'chessalyzer/trackers';
 
-import WorkerPool from '#core/worker-pool';
-import type { WorkerMessage } from '#types/worker';
 import { fixturePath } from '~/test/helpers/fixtures';
 
-const workerPath = join(import.meta.dirname, '../../lib/chess-worker.js');
 const badSanPath = join(import.meta.dirname, '../fixtures/bad-san-mid-file.pgn');
 const corruptPath = fixturePath('corrupt');
 
-const minimalChunkBytes = new TextEncoder().encode('[Event "t"]\n\n1. e4 1-0\n');
+describe('analyzePGN multithreaded', () => {
+    it('aborts on first bad game by default', async () => {
+        let caught: unknown;
+        try {
+            await analyzePGN(badSanPath, { trackers: [PieceTracker] });
+        } catch (err) {
+            caught = err;
+        }
 
-async function runTaskWithTimeout(
-    pool: WorkerPool,
-    task: Parameters<WorkerPool['runTask']>[0],
-    timeoutMs: number,
-): Promise<{ err: Error | null; result: WorkerMessage | null }> {
-    const timeout = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('WorkerPool task timed out')), timeoutMs),
-    );
-    const settled = pool.runTask(task).then(
-        (result) => ({ err: null, result }),
-        (err: unknown) => ({
-            err: err instanceof Error ? err : new Error(String(err)),
-            result: null,
-        }),
-    );
-    return Promise.race([settled, timeout]);
-}
-
-describe('Workers', () => {
-    describe('WorkerPool error propagation', () => {
-        let pool: WorkerPool | undefined;
-
-        afterEach(async () => {
-            await pool?.close();
-            pool = undefined;
-        });
-
-        it('returns batch errors to the callback instead of hanging', async () => {
-            pool = new WorkerPool(1, workerPath, {
-                configs: [
-                    {
-                        trackerData: [{ id: 'DoesNotExist' }],
-                        replayMode: 'skip',
-                    },
-                ],
-            });
-
-            const { err, result } = await runTaskWithTimeout(
-                pool,
-                {
-                    pgnChunkBytes: minimalChunkBytes,
-                    configs: [{ idxConfig: 0, parseHeaders: false }],
-                },
-                10_000,
-            );
-
-            expect(err).toBeInstanceOf(Error);
-            expect(err?.message).toContain('Unknown tracker');
-            expect(result === null || result?.error !== undefined || err !== null).toBe(true);
-        });
+        expect(caught).toBeDefined();
+        expect(caught).toBeInstanceOf(Error);
     });
 
-    describe('analyzePGN multithreaded', () => {
-        it('aborts on first bad game by default', async () => {
-            let caught: unknown;
-            try {
-                await analyzePGN(badSanPath, { trackers: [PieceTracker] });
-            } catch (err) {
-                caught = err;
-            }
+    it('processes corrupt.pgn with an incomplete trailing game without hanging', async () => {
+        const tileTracker = TileTracker;
+        const data = await Promise.race([
+            analyzePGN(corruptPath, { trackers: [tileTracker] }),
+            new Promise<never>((_, reject) =>
+                setTimeout(() => reject(new Error('analyzePGN timed out')), 10_000),
+            ),
+        ]);
 
-            expect(caught).toBeDefined();
-            expect(caught).toBeInstanceOf(Error);
-        });
-
-        it('processes corrupt.pgn with an incomplete trailing game without hanging', async () => {
-            const tileTracker = TileTracker;
-            const data = await Promise.race([
-                analyzePGN(corruptPath, { trackers: [tileTracker] }),
-                new Promise<never>((_, reject) =>
-                    setTimeout(() => reject(new Error('analyzePGN timed out')), 10_000),
-                ),
-            ]);
-
-            expect(data.gameCount).toBe(1);
-            expect(data.moveCount).toBe(15);
-            const state = getTrackerState(data, tileTracker);
-            expect(state.movesTotal).toBeGreaterThan(0);
-        });
+        expect(data.gameCount).toBe(1);
+        expect(data.moveCount).toBe(15);
+        const state = getTrackerState(data, tileTracker);
+        expect(state.movesTotal).toBeGreaterThan(0);
     });
 });


### PR DESCRIPTION
- Unit tests should always import from src, while integration tests should run against the built library
- Updated the bench:perf script and adapted the agent instructions