### PR TITLE
fix: use `fileURLToPath` for cross-platform compat

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "oxlint": "^1.76.0",
         "oxlint-tsgolint": "^7.0.2001",
         "tinybench": "^6.1.2",
-        "tsx": "^4.23.1",
+        "tsx": "^4.23.4",
         "typescript": "6.0.3",
       },
     },
@@ -1032,7 +1032,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
+    "tsx": ["tsx@4.23.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-ZiUQ8oT/KzN51mJUWPqARYqwFLFJZtGZipRkw1ynHMr9vy3eU77m5yfF3Gzm6meEg/beW+lUu3fHYgskTN2oVQ=="],
 
     "turbo-stream": ["turbo-stream@3.2.0", "", {}, "sha512-EK+bZ9UVrVh7JLslVFOV0GEMsociOqVOvEMTAd4ixMyffN5YNIEdLZWXUx5PJqDbTxSIBWw04HS9gCY4frYQDQ=="],
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "oxlint": "^1.76.0",
         "oxlint-tsgolint": "^7.0.2001",
         "tinybench": "^6.1.2",
-        "tsx": "^4.23.1",
+        "tsx": "^4.23.4",
         "typescript": "6.0.3"
     },
     "overrides": {

--- a/scripts/build-fixture-manifest.ts
+++ b/scripts/build-fixture-manifest.ts
@@ -8,11 +8,12 @@
  */
 import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { analyzePGN } from '#core/analyze';
 import type { AnalyzeOptions } from '#types/analysis';
 
-const FIXTURES_DIR = new URL('../test/fixtures/', import.meta.url).pathname;
+const FIXTURES_DIR = fileURLToPath(new URL('../test/fixtures/', import.meta.url));
 const MANIFEST_PATH = join(FIXTURES_DIR, 'manifest.json');
 
 const descriptions: Record<string, string> = {

--- a/src/board/piece-positions.ts
+++ b/src/board/piece-positions.ts
@@ -86,8 +86,6 @@ export default class PiecePositions {
                 return this.Q;
             case 'K':
                 return this.K;
-            default:
-                return this.K;
         }
     }
 

--- a/src/core/__tests__/worker-pool.test.ts
+++ b/src/core/__tests__/worker-pool.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, afterEach } from 'bun:test';
+import { fileURLToPath } from 'node:url';
 
 import WorkerPool from '#core/worker-pool';
 import type { WorkerMessage } from '#types/worker';
 
 /** Valid stub — only used once a worker is actually spawned. */
-const stubWorkerPath = new URL('fixtures/stub-worker.ts', import.meta.url).pathname;
-const stubErrorWorkerPath = new URL('fixtures/stub-error-worker.ts', import.meta.url).pathname;
+const stubWorkerPath = fileURLToPath(new URL('fixtures/stub-worker.ts', import.meta.url));
+const stubErrorWorkerPath = fileURLToPath(
+    new URL('fixtures/stub-error-worker.ts', import.meta.url),
+);
 /** Guaranteed missing — used to prove filePath is validated at spawn time. */
-const missingWorkerPath = new URL('fixtures/does-not-exist-worker.ts', import.meta.url).pathname;
+const missingWorkerPath = fileURLToPath(
+    new URL('fixtures/does-not-exist-worker.ts', import.meta.url),
+);
 
 function minimalChunkBytes(): Uint8Array {
     // Fresh buffer per task: WorkerPool transfers the ArrayBuffer, which detaches it.

--- a/src/core/game-processor.ts
+++ b/src/core/game-processor.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { availableParallelism } from 'node:os';
-import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import type { NormalizedAnalyzeOptions } from '#core/analysis-config';
 import {
@@ -19,7 +19,7 @@ import { toParsedGame } from '#types/parse-pgn';
 import type { WorkerBatchTask, WorkerInitData, WorkerTaskConfigEntry } from '#types/worker';
 
 /** Path to the worker file. */
-const WORKER_PATH = join(import.meta.dirname, 'chess-worker.js');
+const WORKER_PATH = fileURLToPath(new URL('chess-worker.js', import.meta.url));
 
 /**
  * Orchestrates PGN I/O, optional worker dispatch, SAN replay, and tracker merge.

--- a/src/io/__tests__/line-reader.test.ts
+++ b/src/io/__tests__/line-reader.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from 'bun:test';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { openLineStream, readLines } from '#io/line-reader';
 
-const FIXTURES_DIR = join(new URL('../../../test/fixtures', import.meta.url).pathname);
+const FIXTURES_DIR = fileURLToPath(new URL('../../../test/fixtures', import.meta.url));
 const CRLF_FIXTURE = join(FIXTURES_DIR, 'crlf-endings.pgn');
-const TMP_DIR = join(new URL('../../../test/.tmp', import.meta.url).pathname);
+const TMP_DIR = fileURLToPath(new URL('../../../test/.tmp', import.meta.url));
 
 async function writeTmpPgn(name: string, content: string): Promise<string> {
     await mkdir(TMP_DIR, { recursive: true });

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1,8 +1,8 @@
+// Runtime
+export { algebraicToCoords, coordsToSquare, squareToCoords } from '#board/board-coords';
+
 // Types
 export type { Action, BaseAction, CaptureAction, MoveAction, PromoteAction } from '#types/actions';
 export type { BoardCoord, Square } from '#board/board-coords';
 export type { PlayerColor } from '#types/tokens';
 export type { ReplayMode } from '#replay/replay-mode';
-
-// Runtime
-export { algebraicToCoords, coordsToSquare, squareToCoords } from '#board/board-coords';

--- a/src/trackers/index.ts
+++ b/src/trackers/index.ts
@@ -3,15 +3,13 @@ export { defineGameTracker, defineMoveTracker } from '#trackers/define-tracker';
 export { GameTracker, type GameTrackerState } from '#trackers/game-tracker';
 export { PieceTracker, type PieceTrackerState } from '#trackers/piece-tracker';
 export { TileTracker, type TileTrackerState } from '#trackers/tile/tile-tracker';
-
 export { generateComparisonHeatmap, generateHeatmap } from '#trackers/heatmap-utils';
 export { PieceHeatmapPresets } from '#trackers/heatmaps/piece-heatmaps';
 export { TileHeatmapPresets } from '#trackers/heatmaps/tile-heatmaps';
-
-export type { Piece } from '#trackers/piece-types';
 export { isTrackedPiece } from '#trackers/piece-types';
 
 // Types
+export type { Piece } from '#trackers/piece-types';
 export type { SquareData } from '#types/game';
 export type {
     AnalyzeTrackerResult,

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -6,11 +6,12 @@
  */
 import { access, mkdir, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import corpusManifest from '~/test/corpus/manifest.json';
 import manifest from '~/test/fixtures/manifest.json';
 
-const TEST_DIR = new URL('..', import.meta.url).pathname;
+const TEST_DIR = fileURLToPath(new URL('..', import.meta.url));
 const FIXTURES_DIR = join(TEST_DIR, 'fixtures');
 const CORPUS_DIR = join(TEST_DIR, 'corpus');
 const TMP_DIR = join(TEST_DIR, '.tmp');


### PR DESCRIPTION
Raw URLs can create wrong file paths on windows. Wrap in fileURLToPath.