### PR TITLE
docs: update docs and jsdocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`chessalyzer/pgn`** — `parsePGN` and `streamParsePGN` for parse-only workflows (no board replay).
+- **Per-run error fields** — `AnalyzeRunResult.skippedGames` and `AnalyzeRunResult.errors` when `onError: 'skip-game'` (call-level totals unchanged).
+- **Piece identity on replay actions** — `BoardPieceName`, `PromotedPieceName`, and `isPromotedPieceName()`; `MoveAction.piece` and capture fields use `BoardPieceName | null` instead of `string | null`. Exported from `chessalyzer/replay` and `chessalyzer/trackers`.
+- **Built-in state sub-shapes** on `/trackers` — `TileStats`, `ColorBucket`, `TileCell`, `TileGrid`, `PieceStatsMap`.
+- **`HeatmapData`** re-exported from the main `chessalyzer` entry (alongside `printHeatmap`).
+
 ### Changed
 
 - **Tracker API (breaking):** Built-ins are camelCase factories — `tileTracker()`, `pieceTracker()`, `gameTracker()` — that return `TrackerInstance` handles. Pass instances to `analyzePGN`; read accumulated stats from `instance.state` (typed). Multi-run cohorts need distinct instances. `defineGameTracker` / `defineMoveTracker` return a factory; default-export that factory for MT. Options are passed to the factory call (`myTracker({ minElo: 2000 })`), not stored on the definition — workers import the factory and call it with those options. Worker merge snapshots are keyed by run-local **index** (`TrackerSnapshot { index, state }`), so two instances of the same tracker id in one run merge correctly. The same instance may accumulate across separate `analyzePGN` calls; reusing it twice in one call (or while another call is in flight) throws.
+- **`AnalyzeOptions` (breaking):** Discriminated threading union — `filter` requires `workers: false`; cannot combine `runs` with top-level `trackers` / `filter` / `maxGames`; `runs` must be non-empty. `replay` and `headers` are inferred from tracker instances where possible (`move` trackers require `replay: 'actions'`; game trackers require headers). `merge` is required on custom tracker definitions.
+- **Open union types:** `AnalyzeError.code`, `ReplayErrorReason`, and `ReplayMode` use `OpenUnion<T>` (`T | (string & {})`) so future literal values type-check without forcing `string`.
+- **Export hygiene:** `WorkerChunkOptions` replaces the internal `PgnChunkConfig` leak in public `.d.ts` files; runtime helpers moved out of `src/types/` (`toParsedGame`, `isGameResult`, `resolveStandaloneParseOptions` → `#pgn/`).
+- **Single-threaded filters:** `toParsedGame` is materialized at most once per game and shared across filtered runs and game trackers in the same pass (~14% faster on multi-run filtered ST benchmarks).
 - **Heatmaps:** Scoped presets are factories — e.g. `TileHeatmapPresets.PIECE_MOVED_TO_TILE({ color: 'w', name: 'Qd' })` and `TILE_OCC_BY_PIECE('e4')` — instead of passing `{ square }` to `generateHeatmap`. Piece-scoped presets take a `HeatmapPieceRef` (`{ color, name }` with starting-piece names like `Qd`, `Nb`, `Pa`). Dropped `GenerateHeatmapOptions` and `refSquare` from `HeatmapAnalysisArgs`; close over scope in custom functions.
 
 ### Removed

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -8,16 +8,18 @@ For what exists now, see [README.md](./README.md) and [AGENTS.md](./AGENTS.md).
 
 ## Current scope (baseline)
 
-Today the library is optimized for **batch analysis**, not general-purpose PGN I/O:
+Today the library is optimized for **batch analysis** on trusted Lichess-style PGN:
 
-- Single public entry point: `analyzePGN(path, options?)`
-- Internal pipeline: I/O (stream lines) → PGN parse → replay when needed → analyze (trackers)
+- **Analysis:** `analyzePGN(path, options?)` — full pipeline with optional trackers, filters (single-threaded), and worker pool (default).
+- **Parse-only:** `chessalyzer/pgn` exports `parsePGN` and `streamParsePGN` for headers + mainline SAN strings without board replay.
+- **Replay types:** `chessalyzer/replay` exports `Action`, `ReplayMode`, `BoardPieceName`, and board coordinate helpers.
+- Internal pipeline: I/O (stream lines or worker chunks) → PGN parse → replay when needed → analyze (trackers)
 - Count-only runs (no move trackers): board replay skipped by default; move counts come from the parsed SAN list length
 - When replay runs without move trackers: `SanApplier` (direct board mutation, no `Action` objects)
 - Tracker path: `SanDecoder` → `Action[]` → `board.applyActions()`
 - Assumes **standard chess from the initial position**, **valid Lichess-style PGN**, **mainline only** (parentheses stripped)
 
-There is no exported parse API, no configurable parsing mode, and no move legality validation beyond disambiguation heuristics.
+Filters are JavaScript predicates (`workers: false` only). There is no serializable filter DSL, no move legality validation beyond disambiguation heuristics, and no per-run `replay` / `onError` overrides yet.
 
 ---
 

--- a/docs/content/docs/error-handling.mdx
+++ b/docs/content/docs/error-handling.mdx
@@ -35,7 +35,17 @@ const result = await analyzePGN('<pathToPgnFile>', { onError: 'skip-game' });
 console.log(result.gameCount, result.skippedGames, result.errors, result.errorsTruncated);
 ```
 
-`result.errors` holds up to 100 typed replay errors (`gameIndex`, `moveIndex`, `san`, `reason`). If more than 100 games fail, `result.errorsTruncated` is `true`.
+`result.errors` holds up to 100 typed replay errors (`gameIndex`, `moveIndex`, `san`, `reason`) summed across all runs. If more than 100 games fail, `result.errorsTruncated` is `true`.
+
+With multiple `runs`, each `result.runs[i]` may also include `skippedGames` and `errors` for that cohort only (omitted when zero).
+
+```javascript
+for (const [i, run] of result.runs.entries()) {
+    if (run.errors?.length) {
+        console.log(`Run ${i}: ${run.skippedGames} skipped, ${run.errors.length} errors`);
+    }
+}
+```
 
 The library never logs to the console for you — you decide what to do with the errors.
 

--- a/docs/content/docs/multithreading.mdx
+++ b/docs/content/docs/multithreading.mdx
@@ -22,7 +22,7 @@ console.log(tiles.state.movesTotal);
 
 The `workers` option lets you tune the thread count and PGN chunk size; defaults are fine for most files.
 
-Workers accumulate tracker state locally and send plain `{ index, state }` snapshots back at pool drain. The main thread merges them into your instance handles.
+Workers accumulate tracker state locally and send plain `{ index, state }` snapshots back at pool drain. The main thread merges them with **`merge`** on your instances, then runs **`onFinish`** once. Per-game **`onGameEnd`** hooks run on workers, not on the main thread. See [Custom trackers](/docs/trackers/custom#hook-lifecycle).
 
 ## Single-threaded mode
 

--- a/docs/content/docs/trackers/custom.mdx
+++ b/docs/content/docs/trackers/custom.mdx
@@ -25,10 +25,57 @@ export default defineGameTracker({
         // fold worker state into main state
     },
     onFinish: (state) => {
-        // optional end-of-analysis hook
+        // optional end-of-analysis hook (main thread only)
     },
 });
 ```
+
+## `defineMoveTracker` walkthrough
+
+Move trackers receive decoded **`Action[]`** per half-move. They require `replay: 'actions'` (inferred automatically when you pass a move tracker to `analyzePGN`).
+
+This example counts half-moves and captures:
+
+```javascript
+// half-move-counter.ts
+import { defineMoveTracker } from 'chessalyzer/trackers';
+
+export default defineMoveTracker({
+    id: 'half-move-counter',
+    workerModule: import.meta.url,
+    init: () => ({ halfMoves: 0, captures: 0 }),
+    track: (state, actions) => {
+        state.halfMoves += 1;
+        for (const action of actions) {
+            if (action.type === 'capture') {
+                state.captures += 1;
+            }
+        }
+    },
+    merge: (state, other) => {
+        state.halfMoves += other.halfMoves;
+        state.captures += other.captures;
+    },
+});
+```
+
+```javascript
+import { analyzePGN } from 'chessalyzer';
+import halfMoveCounter from './half-move-counter.ts';
+
+const counter = halfMoveCounter();
+
+await analyzePGN(path, { trackers: [counter] });
+// replay: 'actions' is inferred from the move tracker
+
+console.log(counter.state.halfMoves, counter.state.captures);
+```
+
+**Action tips:**
+
+- `SanDecoder` reuses the same `Action` objects each half-move — copy fields you need to retain across moves.
+- **Castling** produces two move actions (king leg, then rook leg). The rook leg carries the same `castle` flag.
+- `action.piece` / `takingPiece` / `takenPiece` use `BoardPieceName` (`Pa`, `Nb`, … or promoted names like `Q17`). Use `isTrackedPiece()` when indexing starting-piece matrices.
 
 ## Usage
 
@@ -54,20 +101,30 @@ Custom trackers need:
 
 Workers import the factory and call it with the options you passed on the main thread. Options must be plain structured-cloneable data.
 
+### Hook lifecycle
+
+| Hook        | Single-threaded (`workers: false`)      | Worker thread (default pool)    | Main thread (default pool)                 |
+| ----------- | --------------------------------------- | ------------------------------- | ------------------------------------------ |
+| `init`      | At factory call                         | Worker calls factory + `init`   | Factory + `init` on your instances         |
+| `track`     | Each game / half-move                   | Each game / half-move on worker | —                                          |
+| `onGameEnd` | After each game (including replay skip) | Same on worker                  | —                                          |
+| `merge`     | —                                       | —                               | When worker snapshots arrive at pool drain |
+| `onFinish`  | Once at end of analysis                 | —                               | Once after all merges (`finishTrackers`)   |
+
+Under multithreading the main thread only drives **`merge`** and **`onFinish`** on your instances. Per-game hooks run on workers. State must be plain data (structured-cloneable) so snapshots can cross the worker boundary.
+
 ## Imports
 
 ```javascript
 import type { ParsedGame, ParsedMove } from 'chessalyzer/pgn';
-import type { Action, Square } from 'chessalyzer/replay';
+import type { Action, BoardPieceName, Square } from 'chessalyzer/replay';
 import { defineGameTracker, defineMoveTracker } from 'chessalyzer/trackers';
 ```
 
 ## Notes
 
 - **`workerModule = import.meta.url`** requires an unbundled Node ≥ 22 or Bun runtime.
-- **Move trackers:** `SanDecoder` reuses an `Action[]` buffer each half-move. Copy fields you need to retain across moves.
-- **Castling** produces two move actions (king leg, then rook leg). The rook leg carries the same `castle` flag.
-- Override **`onGameEnd(state)`** for per-game flush hooks and **`onFinish(state)`** for end-of-analysis hooks.
+- Override **`onGameEnd(state)`** for per-game flush hooks and **`onFinish(state)`** for end-of-analysis hooks on the main thread.
 
 See [`manual-tests/custom-game-tracker.ts`](https://github.com/yschroe/chessalyzer/blob/main/manual-tests/custom-game-tracker.ts) for a minimal working example.
 

--- a/src/types/tracker.ts
+++ b/src/types/tracker.ts
@@ -9,11 +9,22 @@ export interface TrackerDefBase<S = unknown, O = unknown> {
     /** Module URL for worker-side dynamic import of custom trackers (multithreaded only). */
     readonly workerModule?: string;
     init(options?: O): S;
-    /** Aggregate worker batch state into the main-thread state. */
+    /**
+     * Aggregate worker batch state into the main-thread state (multithreaded only).
+     * Called on the main thread when worker snapshots are merged at pool drain.
+     */
     merge(state: S, other: S): void;
-    /** Optional per-game hook after each game (success or skip). */
+    /**
+     * Optional per-game hook after each game completes processing.
+     * Runs on the worker in multithreaded mode and on the main thread when `workers: false`.
+     * Still called when replay fails and `onError: 'skip-game'` skips the game (after `track` for that game).
+     */
     onGameEnd?(state: S): void;
-    /** Optional end-of-analysis hook (e.g. sort aggregated keys). */
+    /**
+     * Optional end-of-analysis hook (e.g. sort aggregated keys).
+     * Runs once on the main thread after all games are processed (`finishTrackers`).
+     * Not invoked on worker threads — use `merge` to fold worker-local finalization if needed.
+     */
     onFinish?(state: S): void;
 }
 

--- a/test/types/api.type-test.ts
+++ b/test/types/api.type-test.ts
@@ -3,7 +3,7 @@
  * Positive paths and `@ts-expect-error` guards for illegal analyzePGN options.
  */
 import { analyzePGN } from '#core/analyze';
-import { defineGameTracker } from '#trackers/define-tracker';
+import { defineGameTracker, defineMoveTracker } from '#trackers/define-tracker';
 import { gameTracker } from '#trackers/game-tracker';
 import { tileTracker } from '#trackers/tile/tile-tracker';
 
@@ -33,6 +33,23 @@ async function validMultiRun() {
             { trackers: [whiteWins], filter: (game) => game.result === '1-0' },
         ],
     });
+}
+
+async function validMoveTracker() {
+    const counter = defineMoveTracker({
+        id: 'moves',
+        workerModule: import.meta.url,
+        init: () => ({ n: 0 }),
+        track: (s, actions) => {
+            s.n += actions.length;
+        },
+        merge: (s, o) => {
+            s.n += o.n;
+        },
+    })();
+    await analyzePGN('x', { trackers: [counter] });
+    const n: number = counter.state.n;
+    return n;
 }
 
 async function invalidConfigs() {
@@ -69,4 +86,5 @@ async function invalidConfigs() {
 void validSingleRun();
 void validFilteredRun();
 void validMultiRun();
+void validMoveTracker();
 void invalidConfigs();


### PR DESCRIPTION
- Added `parsePGN` and `streamParsePGN` for parse-only workflows in `chessalyzer/pgn`.
- Introduced per-run error fields in `AnalyzeRunResult` for better error handling.
- Enhanced piece identity handling in replay actions with new types and fields.
- Added built-in state sub-shapes in `/trackers` for improved data structure.
- Re-exported `HeatmapData` from the main `chessalyzer` entry.
- Updated Tracker API and `AnalyzeOptions` with breaking changes for improved clarity and functionality.
- Enhanced documentation for multithreading and custom trackers, including lifecycle hooks and usage examples.